### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/188/081/421188081.geojson
+++ b/data/421/188/081/421188081.geojson
@@ -57,6 +57,9 @@
     },
     "wof:country":"SD",
     "wof:created":1459009533,
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"0ad499453b3f4389ae3de9fd5fe15ee2",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":421188081,
-    "wof:lastmodified":1527716291,
+    "wof:lastmodified":1582318342,
     "wof:name":"Sudan",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/421/189/751/421189751.geojson
+++ b/data/421/189/751/421189751.geojson
@@ -220,6 +220,9 @@
     },
     "wof:country":"SD",
     "wof:created":1459009635,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1b4b1c02dc8e94ccfbaf97d68381f1e1",
     "wof:hierarchy":[
         {
@@ -231,7 +234,7 @@
         }
     ],
     "wof:id":421189751,
-    "wof:lastmodified":1566639635,
+    "wof:lastmodified":1582318342,
     "wof:name":"Al Ubayyid",
     "wof:parent_id":1091710639,
     "wof:placetype":"locality",

--- a/data/421/189/753/421189753.geojson
+++ b/data/421/189/753/421189753.geojson
@@ -292,6 +292,9 @@
     },
     "wof:country":"SD",
     "wof:created":1459009635,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"4400235a195fee959d4b6ba04b94961d",
     "wof:hierarchy":[
         {
@@ -303,7 +306,7 @@
         }
     ],
     "wof:id":421189753,
-    "wof:lastmodified":1566639634,
+    "wof:lastmodified":1582318342,
     "wof:name":"Dongola",
     "wof:parent_id":1091705759,
     "wof:placetype":"locality",

--- a/data/421/189/759/421189759.geojson
+++ b/data/421/189/759/421189759.geojson
@@ -279,6 +279,7 @@
     "qs:woe_id":1433451,
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "quattroshapes_pg"
     ],
     "wd:latitude":15.45,
@@ -302,6 +303,10 @@
     },
     "wof:country":"SD",
     "wof:created":1459009635,
+    "wof:geom_alt":[
+        "naturalearth",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5858229293d64da74ea42aeb20f4d940",
     "wof:hierarchy":[
         {
@@ -313,7 +318,7 @@
         }
     ],
     "wof:id":421189759,
-    "wof:lastmodified":1566639635,
+    "wof:lastmodified":1582318342,
     "wof:name":"Kassala",
     "wof:parent_id":1091708105,
     "wof:placetype":"locality",

--- a/data/856/327/51/85632751.geojson
+++ b/data/856/327/51/85632751.geojson
@@ -969,6 +969,10 @@
     },
     "wof:country":"SD",
     "wof:country_alpha3":"SDN",
+    "wof:geom_alt":[
+        "naturalearth",
+        "meso"
+    ],
     "wof:geomhash":"9ba055eee04b5716cb3c8a2e894e1a2e",
     "wof:hierarchy":[
         {
@@ -985,7 +989,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1566639141,
+    "wof:lastmodified":1582318332,
     "wof:name":"Sudan",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/768/65/85676865.geojson
+++ b/data/856/768/65/85676865.geojson
@@ -442,6 +442,9 @@
         "wd:id":"Q309489"
     },
     "wof:country":"SD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"111a461c877f2b76b8be36aadd73312e",
     "wof:hierarchy":[
         {
@@ -459,7 +462,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1566639139,
+    "wof:lastmodified":1582318331,
     "wof:name":"Blue Nile",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/768/67/85676867.geojson
+++ b/data/856/768/67/85676867.geojson
@@ -311,6 +311,9 @@
         "wd:id":"Q310120"
     },
     "wof:country":"SD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e64d06de23defcaadb9a88949deb1e0f",
     "wof:hierarchy":[
         {
@@ -328,7 +331,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1566639137,
+    "wof:lastmodified":1582318329,
     "wof:name":"Red Sea",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/768/71/85676871.geojson
+++ b/data/856/768/71/85676871.geojson
@@ -228,6 +228,9 @@
         "wd:id":"Q838778"
     },
     "wof:country":"SD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"59ec477a917edaa9bc7024673a6063b5",
     "wof:hierarchy":[
         {
@@ -245,7 +248,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1566639140,
+    "wof:lastmodified":1582318331,
     "wof:name":"Southern Darfur",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/768/75/85676875.geojson
+++ b/data/856/768/75/85676875.geojson
@@ -82,6 +82,9 @@
         "qs_pg:id":895509
     },
     "wof:country":"SD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3e31e898da5fe00fb43dd654648089ff",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1566639138,
+    "wof:lastmodified":1582318330,
     "wof:name":"Eastern Darfur",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/768/81/85676881.geojson
+++ b/data/856/768/81/85676881.geojson
@@ -219,6 +219,9 @@
         "wd:id":"Q846331"
     },
     "wof:country":"SD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c0148b1cb79fc98d81fe2a2fb10c32bd",
     "wof:hierarchy":[
         {
@@ -236,7 +239,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1566639138,
+    "wof:lastmodified":1582318330,
     "wof:name":"Western Darfur",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/768/85/85676885.geojson
+++ b/data/856/768/85/85676885.geojson
@@ -204,6 +204,9 @@
         "wd:id":"Q4116493"
     },
     "wof:country":"SD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3d5a5eb0df9175a24b7d88f0f303cd77",
     "wof:hierarchy":[
         {
@@ -221,7 +224,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1566639140,
+    "wof:lastmodified":1582318331,
     "wof:name":"Central Darfur",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/768/89/85676889.geojson
+++ b/data/856/768/89/85676889.geojson
@@ -562,6 +562,9 @@
         "wd:id":"Q310385"
     },
     "wof:country":"SD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"36d420aa838da981ac37d54e5ebe5d92",
     "wof:hierarchy":[
         {
@@ -579,7 +582,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1566639138,
+    "wof:lastmodified":1582318330,
     "wof:name":"Khartoum",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/768/93/85676893.geojson
+++ b/data/856/768/93/85676893.geojson
@@ -289,6 +289,9 @@
         "wd:id":"Q309469"
     },
     "wof:country":"SD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4c151b2982e68a8de3e20fcbe285a9e3",
     "wof:hierarchy":[
         {
@@ -306,7 +309,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1566639138,
+    "wof:lastmodified":1582318330,
     "wof:name":"Gezira",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/768/97/85676897.geojson
+++ b/data/856/768/97/85676897.geojson
@@ -287,6 +287,9 @@
         "wd:id":"Q309478"
     },
     "wof:country":"SD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c778be8b60cc59cefa27fdff34057dde",
     "wof:hierarchy":[
         {
@@ -304,7 +307,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1566639139,
+    "wof:lastmodified":1582318331,
     "wof:name":"Gedarif",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/769/01/85676901.geojson
+++ b/data/856/769/01/85676901.geojson
@@ -295,6 +295,9 @@
         "wd:id":"Q849297"
     },
     "wof:country":"SD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"af0fe649cc45d3d98d2d153549f4a560",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1566639136,
+    "wof:lastmodified":1582318329,
     "wof:name":"River Nile",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/769/05/85676905.geojson
+++ b/data/856/769/05/85676905.geojson
@@ -291,6 +291,9 @@
         "wd:id":"Q310118"
     },
     "wof:country":"SD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"62d56a81acd18b429080b4bd7b9fc252",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1566639134,
+    "wof:lastmodified":1582318328,
     "wof:name":"Northern",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/769/09/85676909.geojson
+++ b/data/856/769/09/85676909.geojson
@@ -420,6 +420,9 @@
         "wd:id":"Q311371"
     },
     "wof:country":"SD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4c95dcb7af1b71a0a186a1cfbb603be5",
     "wof:hierarchy":[
         {
@@ -437,7 +440,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1566639135,
+    "wof:lastmodified":1582318329,
     "wof:name":"White Nile",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/769/15/85676915.geojson
+++ b/data/856/769/15/85676915.geojson
@@ -285,6 +285,9 @@
         "wd:id":"Q865534"
     },
     "wof:country":"SD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"13b4cc642e45bb73a4bfb9a0976ca108",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1566639136,
+    "wof:lastmodified":1582318329,
     "wof:name":"Sennar",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/769/19/85676919.geojson
+++ b/data/856/769/19/85676919.geojson
@@ -300,6 +300,9 @@
         "wd:id":"Q688306"
     },
     "wof:country":"SD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9ea2083c56e1a6ea97ae95b9634932f1",
     "wof:hierarchy":[
         {
@@ -317,7 +320,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1566639135,
+    "wof:lastmodified":1582318328,
     "wof:name":"North Darfur",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/769/23/85676923.geojson
+++ b/data/856/769/23/85676923.geojson
@@ -306,6 +306,9 @@
         "wd:id":"Q465490"
     },
     "wof:country":"SD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2da4083f8448df79d0791d4115f8accc",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1566639136,
+    "wof:lastmodified":1582318329,
     "wof:name":"South Kordufan",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/769/25/85676925.geojson
+++ b/data/856/769/25/85676925.geojson
@@ -293,6 +293,9 @@
         "wd:id":"Q864093"
     },
     "wof:country":"SD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"758871205e4bf1c5b60594fb694f4e9b",
     "wof:hierarchy":[
         {
@@ -310,7 +313,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1566639136,
+    "wof:lastmodified":1582318329,
     "wof:name":"North Kordufan",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/769/29/85676929.geojson
+++ b/data/856/769/29/85676929.geojson
@@ -282,6 +282,9 @@
         "wd:id":"Q954963"
     },
     "wof:country":"SD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c21b748e9ecfb6953c377a054ca7da93",
     "wof:hierarchy":[
         {
@@ -299,7 +302,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1566639134,
+    "wof:lastmodified":1582318328,
     "wof:name":"Kassala",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/859/029/05/85902905.geojson
+++ b/data/859/029/05/85902905.geojson
@@ -113,6 +113,9 @@
         "wd:id":"Q4703088"
     },
     "wof:country":"SD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2cfe17d127bb23b0b63693e9a60d70a6",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566639134,
+    "wof:lastmodified":1582318328,
     "wof:name":"Al Qawz",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/041/75/85904175.geojson
+++ b/data/859/041/75/85904175.geojson
@@ -65,6 +65,9 @@
         "gp:id":10644826
     },
     "wof:country":"SD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"47e9689060e096ce855bd4d7a90ae4ea",
     "wof:hierarchy":[
         {
@@ -80,7 +83,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566639133,
+    "wof:lastmodified":1582318327,
     "wof:name":"Khartoum Airport",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/041/77/85904177.geojson
+++ b/data/859/041/77/85904177.geojson
@@ -130,6 +130,10 @@
         "wd:id":"Q656871"
     },
     "wof:country":"SD",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d02dc4738881b768c78ee8d46e5d210a",
     "wof:hierarchy":[
         {
@@ -145,7 +149,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566639134,
+    "wof:lastmodified":1582318327,
     "wof:name":"University of Khartoum",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/041/79/85904179.geojson
+++ b/data/859/041/79/85904179.geojson
@@ -68,6 +68,10 @@
         "qs_pg:id":424982
     },
     "wof:country":"SD",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8edb1f6a5636c0bdc6ddf5e05a6e0fb7",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566639133,
+    "wof:lastmodified":1582318327,
     "wof:name":"Friendship Hall",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/041/83/85904183.geojson
+++ b/data/859/041/83/85904183.geojson
@@ -88,6 +88,10 @@
         "qs_pg:id":1208214
     },
     "wof:country":"SD",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"2122be2e9bf0aca2eec6c72f2f2d451f",
     "wof:hierarchy":[
         {
@@ -103,7 +107,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566639134,
+    "wof:lastmodified":1582318327,
     "wof:name":"Ministry of Education",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/441/687/890441687.geojson
+++ b/data/890/441/687/890441687.geojson
@@ -580,6 +580,9 @@
     },
     "wof:country":"SD",
     "wof:created":1469052333,
+    "wof:geom_alt":[
+        "unknown"
+    ],
     "wof:geomhash":"1fd00e72293b4074882cdafcb2fead71",
     "wof:hierarchy":[
         {
@@ -591,7 +594,7 @@
         }
     ],
     "wof:id":890441687,
-    "wof:lastmodified":1566639639,
+    "wof:lastmodified":1582318342,
     "wof:name":"Khartoum",
     "wof:parent_id":1091707383,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.