### PR TITLE
Update non-ascii names, store existing localized names

### DIFF
--- a/data/421/189/761/421189761.geojson
+++ b/data/421/189/761/421189761.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632751,
-        85676889,
-        1091707383
+        1091707383,
+        85676889
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421189761,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423090,
     "wof:name":"Khartoum",
     "wof:parent_id":1091707383,
     "wof:placetype":"locality",

--- a/data/421/189/761/421189761.geojson
+++ b/data/421/189/761/421189761.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062e\u0631\u0637\u0648\u0645"
+    ],
+    "name:eng_x_preferred":[
+        "Khartoum"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421189761,
-    "wof:lastmodified":1566639635,
-    "wof:name":"\u0627\u0644\u062e\u0631\u0637\u0648\u0645",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Khartoum",
     "wof:parent_id":1091707383,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sd",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/183.

This PR updates loclized `wof:name` values in records that currently have no `name:eng_x_*` properties. There are other records that will need to be updated as part of this work too, but those will be handled in a separate PR.

The existing `wof:name` should be stored in the appropriate `name:*` property, with `wof:name` and `name:eng_x_preferred` properties getting updated English name values.

No PIP work needed, these are just property updates.