### PR TITLE
Update properties of megacities

### DIFF
--- a/data/890/441/687/890441687.geojson
+++ b/data/890/441/687/890441687.geojson
@@ -600,6 +600,7 @@
     ],
     "wof:concordances":{
         "gn:id":379252,
+        "ne:id":1159151275,
         "qs_pg:id":124519,
         "wd:id":"Q1963",
         "wk:page":"Khartoum"
@@ -623,7 +624,8 @@
         }
     ],
     "wof:id":890441687,
-    "wof:lastmodified":1608007111,
+    "wof:lastmodified":1608688183,
+    "wof:megacity":1,
     "wof:name":"Khartoum",
     "wof:parent_id":1091707383,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary