### PR TITLE
sd concordances, placetype local, and more

### DIFF
--- a/data/109/170/523/3/1091705233.geojson
+++ b/data/109/170/523/3/1091705233.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.RN.AH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473879945,
     "wof:geomhash":"2e1e95f6e56f8d1c6dcc621bc744bfd0",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091705233,
-    "wof:lastmodified":1694492789,
+    "wof:lastmodified":1695886462,
     "wof:name":"Abu Hamed",
     "wof:parent_id":85676901,
     "wof:placetype":"county",

--- a/data/109/170/527/5/1091705275.geojson
+++ b/data/109/170/527/5/1091705275.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.SD.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473879946,
     "wof:geomhash":"fd77147d8c4faa10a7e5556dea596f32",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091705275,
-    "wof:lastmodified":1694492790,
+    "wof:lastmodified":1695886465,
     "wof:name":"Bahr El Arab",
     "wof:parent_id":85676875,
     "wof:placetype":"county",

--- a/data/109/170/531/7/1091705317.geojson
+++ b/data/109/170/531/7/1091705317.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"SD.GD.GG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473879948,
     "wof:geomhash":"1bc508b90720721a7aaade0985ed0963",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091705317,
-    "wof:lastmodified":1694492828,
+    "wof:lastmodified":1695886255,
     "wof:name":"Basonda",
     "wof:parent_id":85676897,
     "wof:placetype":"county",

--- a/data/109/170/534/9/1091705349.geojson
+++ b/data/109/170/534/9/1091705349.geojson
@@ -77,6 +77,7 @@
     "wof:concordances":{
         "hasc:id":"SD.WD.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473879949,
     "wof:geomhash":"6f80b2d63088a453e19c11508761d96c",
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1091705349,
-    "wof:lastmodified":1694492395,
+    "wof:lastmodified":1695886317,
     "wof:name":"Beida",
     "wof:parent_id":85676881,
     "wof:placetype":"county",

--- a/data/109/170/539/5/1091705395.geojson
+++ b/data/109/170/539/5/1091705395.geojson
@@ -56,6 +56,7 @@
     "wof:concordances":{
         "hasc:id":"SD.WD.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473879951,
     "wof:geomhash":"af6c9eb966eaa75b88154bf66c3d4145",
@@ -68,7 +69,7 @@
         }
     ],
     "wof:id":1091705395,
-    "wof:lastmodified":1694492833,
+    "wof:lastmodified":1695886267,
     "wof:name":"Bindisi",
     "wof:parent_id":85676885,
     "wof:placetype":"county",

--- a/data/109/170/544/3/1091705443.geojson
+++ b/data/109/170/544/3/1091705443.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.GD.EF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473879952,
     "wof:geomhash":"87a04ca51188c004681d25f2f0b57df5",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091705443,
-    "wof:lastmodified":1694492791,
+    "wof:lastmodified":1695886466,
     "wof:name":"El Fashaga",
     "wof:parent_id":85676897,
     "wof:placetype":"county",

--- a/data/109/170/548/5/1091705485.geojson
+++ b/data/109/170/548/5/1091705485.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.WD.EG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473879953,
     "wof:geomhash":"78225a9f57dcb02dd8847a70672d51cd",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091705485,
-    "wof:lastmodified":1694492790,
+    "wof:lastmodified":1695886463,
     "wof:name":"El Geneina",
     "wof:parent_id":85676881,
     "wof:placetype":"county",

--- a/data/109/170/550/3/1091705503.geojson
+++ b/data/109/170/550/3/1091705503.geojson
@@ -80,7 +80,7 @@
         }
     ],
     "wof:id":1091705503,
-    "wof:lastmodified":1694492792,
+    "wof:lastmodified":1695886469,
     "wof:name":"El Kurmuk",
     "wof:parent_id":85676865,
     "wof:placetype":"county",

--- a/data/109/170/550/3/1091705503.geojson
+++ b/data/109/170/550/3/1091705503.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"SD.BN.EK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473879955,
     "wof:geomhash":"bbc4c8f9cc687efcf0c5cac07b1af90a",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1091705503,
-    "wof:lastmodified":1695886469,
+    "wof:lastmodified":1696023154,
     "wof:name":"El Kurmuk",
     "wof:parent_id":85676865,
     "wof:placetype":"county",

--- a/data/109/170/550/5/1091705505.geojson
+++ b/data/109/170/550/5/1091705505.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.ND.EM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473879956,
     "wof:geomhash":"67751da4c562b1877b156a44eb1e9fc1",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091705505,
-    "wof:lastmodified":1694492791,
+    "wof:lastmodified":1695886466,
     "wof:name":"El Malha",
     "wof:parent_id":85676919,
     "wof:placetype":"county",

--- a/data/109/170/550/7/1091705507.geojson
+++ b/data/109/170/550/7/1091705507.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"SD.ND.KU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473879958,
     "wof:geomhash":"e3debe77f68da3973325ef8a3d452dab",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091705507,
-    "wof:lastmodified":1694492856,
+    "wof:lastmodified":1695886320,
     "wof:name":"Kornoi",
     "wof:parent_id":85676919,
     "wof:placetype":"county",

--- a/data/109/170/550/9/1091705509.geojson
+++ b/data/109/170/550/9/1091705509.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"SD.WD.KU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473879959,
     "wof:geomhash":"7e0c96ff4938804ddfdf6dd898877729",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1091705509,
-    "wof:lastmodified":1694492792,
+    "wof:lastmodified":1695886469,
     "wof:name":"Kulbus",
     "wof:parent_id":85676881,
     "wof:placetype":"county",

--- a/data/109/170/552/1/1091705521.geojson
+++ b/data/109/170/552/1/1091705521.geojson
@@ -185,6 +185,7 @@
         "hasc:id":"SD.KS.TA",
         "wd:id":"Q2390680"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473879961,
     "wof:geomhash":"540ae202fedc29b6012a8946851a7583",
@@ -197,7 +198,7 @@
         }
     ],
     "wof:id":1091705521,
-    "wof:lastmodified":1694492395,
+    "wof:lastmodified":1695886318,
     "wof:name":"Talodi",
     "wof:parent_id":85676923,
     "wof:placetype":"county",

--- a/data/109/170/556/7/1091705567.geojson
+++ b/data/109/170/556/7/1091705567.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.WD.UD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473879962,
     "wof:geomhash":"3ce819101a58ec80440be2736f607f93",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091705567,
-    "wof:lastmodified":1694492793,
+    "wof:lastmodified":1695886472,
     "wof:name":"Umm Dukhun",
     "wof:parent_id":85676885,
     "wof:placetype":"county",

--- a/data/109/170/560/5/1091705605.geojson
+++ b/data/109/170/560/5/1091705605.geojson
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":1091705605,
-    "wof:lastmodified":1694492824,
+    "wof:lastmodified":1695886246,
     "wof:name":"Abu Karinka",
     "wof:parent_id":85676875,
     "wof:placetype":"county",

--- a/data/109/170/564/1/1091705641.geojson
+++ b/data/109/170/564/1/1091705641.geojson
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":1091705641,
-    "wof:lastmodified":1694492825,
+    "wof:lastmodified":1695886247,
     "wof:name":"Ailliet",
     "wof:parent_id":85676919,
     "wof:placetype":"county",

--- a/data/109/170/568/9/1091705689.geojson
+++ b/data/109/170/568/9/1091705689.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"SD.NO.DO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473879967,
     "wof:geomhash":"e72da5f01edfbec07a0ba002349ceafa",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091705689,
-    "wof:lastmodified":1694492825,
+    "wof:lastmodified":1695886248,
     "wof:name":"Alborgag",
     "wof:parent_id":85676905,
     "wof:placetype":"county",

--- a/data/109/170/573/9/1091705739.geojson
+++ b/data/109/170/573/9/1091705739.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.NO.AG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473879968,
     "wof:geomhash":"01123c74c00365f61e85d81acd305698",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091705739,
-    "wof:lastmodified":1694492790,
+    "wof:lastmodified":1695886463,
     "wof:name":"Algolid",
     "wof:parent_id":85676905,
     "wof:placetype":"county",

--- a/data/109/170/575/9/1091705759.geojson
+++ b/data/109/170/575/9/1091705759.geojson
@@ -157,6 +157,7 @@
     "wof:concordances":{
         "hasc:id":"SD.NO.DO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473879970,
     "wof:geomhash":"271acd4d3106fc40c02cc0ba6d88e9b9",
@@ -169,7 +170,7 @@
         }
     ],
     "wof:id":1091705759,
-    "wof:lastmodified":1694492395,
+    "wof:lastmodified":1695886318,
     "wof:name":"Dongola",
     "wof:parent_id":85676905,
     "wof:placetype":"county",

--- a/data/109/170/580/7/1091705807.geojson
+++ b/data/109/170/580/7/1091705807.geojson
@@ -138,7 +138,7 @@
         }
     ],
     "wof:id":1091705807,
-    "wof:lastmodified":1694492925,
+    "wof:lastmodified":1695886658,
     "wof:name":"Babanusa",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/170/585/1/1091705851.geojson
+++ b/data/109/170/585/1/1091705851.geojson
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":1091705851,
-    "wof:lastmodified":1694492826,
+    "wof:lastmodified":1695886250,
     "wof:name":"Assalaya",
     "wof:parent_id":85676875,
     "wof:placetype":"county",

--- a/data/109/170/588/1/1091705881.geojson
+++ b/data/109/170/588/1/1091705881.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.NO.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473879974,
     "wof:geomhash":"dc11a81bfeee6c5afa0cb0d601ea286e",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091705881,
-    "wof:lastmodified":1694492790,
+    "wof:lastmodified":1695886465,
     "wof:name":"Dalgo",
     "wof:parent_id":85676905,
     "wof:placetype":"county",

--- a/data/109/170/592/3/1091705923.geojson
+++ b/data/109/170/592/3/1091705923.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"SD.SD.NY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473879976,
     "wof:geomhash":"bb6dc0baf602a4b77aaa3235cb57af6b",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091705923,
-    "wof:lastmodified":1694492826,
+    "wof:lastmodified":1695886249,
     "wof:name":"Alwehda",
     "wof:parent_id":85676871,
     "wof:placetype":"county",

--- a/data/109/170/596/5/1091705965.geojson
+++ b/data/109/170/596/5/1091705965.geojson
@@ -83,7 +83,7 @@
         }
     ],
     "wof:id":1091705965,
-    "wof:lastmodified":1694492791,
+    "wof:lastmodified":1695886465,
     "wof:name":"Dar El Salam",
     "wof:parent_id":85676919,
     "wof:placetype":"county",

--- a/data/109/170/600/9/1091706009.geojson
+++ b/data/109/170/600/9/1091706009.geojson
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":1091706009,
-    "wof:lastmodified":1694492841,
+    "wof:lastmodified":1695886284,
     "wof:name":"Dimsu",
     "wof:parent_id":85676871,
     "wof:placetype":"county",

--- a/data/109/170/605/3/1091706053.geojson
+++ b/data/109/170/605/3/1091706053.geojson
@@ -100,6 +100,7 @@
     "wof:concordances":{
         "hasc:id":"SD.SD.ED"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473879980,
     "wof:geomhash":"e384129cda1223591b6b14fa88c7deb7",
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1091706053,
-    "wof:lastmodified":1694492395,
+    "wof:lastmodified":1695886318,
     "wof:name":"Ed Daein",
     "wof:parent_id":85676875,
     "wof:placetype":"county",

--- a/data/109/170/609/7/1091706097.geojson
+++ b/data/109/170/609/7/1091706097.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KA.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473879982,
     "wof:geomhash":"3018e913942b13d890d90774760f8937",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091706097,
-    "wof:lastmodified":1694492790,
+    "wof:lastmodified":1695886464,
     "wof:name":"Aroma",
     "wof:parent_id":85676929,
     "wof:placetype":"county",

--- a/data/109/170/614/1/1091706141.geojson
+++ b/data/109/170/614/1/1091706141.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"SD.RN.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473879983,
     "wof:geomhash":"9fb6ec65b2273ae08f2c94128bd52427",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091706141,
-    "wof:lastmodified":1694492842,
+    "wof:lastmodified":1695886287,
     "wof:name":"Ed Damer",
     "wof:parent_id":85676901,
     "wof:placetype":"county",

--- a/data/109/170/617/1/1091706171.geojson
+++ b/data/109/170/617/1/1091706171.geojson
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":1091706171,
-    "wof:lastmodified":1694492825,
+    "wof:lastmodified":1695886247,
     "wof:name":"Al Mafaza",
     "wof:parent_id":85676897,
     "wof:placetype":"county",

--- a/data/109/170/621/5/1091706215.geojson
+++ b/data/109/170/621/5/1091706215.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.SI.ED"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473879986,
     "wof:geomhash":"008a71514249dcfda9e578c4e9e2e069",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091706215,
-    "wof:lastmodified":1694492791,
+    "wof:lastmodified":1695886465,
     "wof:name":"El Dindir",
     "wof:parent_id":85676915,
     "wof:placetype":"county",

--- a/data/109/170/627/5/1091706275.geojson
+++ b/data/109/170/627/5/1091706275.geojson
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":1091706275,
-    "wof:lastmodified":1694492843,
+    "wof:lastmodified":1695886287,
     "wof:name":"El Butana",
     "wof:parent_id":85676897,
     "wof:placetype":"county",

--- a/data/109/170/629/7/1091706297.geojson
+++ b/data/109/170/629/7/1091706297.geojson
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":1091706297,
-    "wof:lastmodified":1694492843,
+    "wof:lastmodified":1695886287,
     "wof:name":"El Faw",
     "wof:parent_id":85676897,
     "wof:placetype":"county",

--- a/data/109/170/631/9/1091706319.geojson
+++ b/data/109/170/631/9/1091706319.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.WN.EG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473879991,
     "wof:geomhash":"1ba0f29253c09a34a6cb4a4202f685c9",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091706319,
-    "wof:lastmodified":1694492790,
+    "wof:lastmodified":1695886464,
     "wof:name":"El Gutaina",
     "wof:parent_id":85676909,
     "wof:placetype":"county",

--- a/data/109/170/634/9/1091706349.geojson
+++ b/data/109/170/634/9/1091706349.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"SD.GZ.EH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473879994,
     "wof:geomhash":"0566d784b9377c2ccd4f82b241bea2e4",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1091706349,
-    "wof:lastmodified":1694492791,
+    "wof:lastmodified":1695886466,
     "wof:name":"El Hasaheesa",
     "wof:parent_id":85676893,
     "wof:placetype":"county",

--- a/data/109/170/636/1/1091706361.geojson
+++ b/data/109/170/636/1/1091706361.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.ND.EF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473879995,
     "wof:geomhash":"b798e13696647c874a42cb3b796e164a",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091706361,
-    "wof:lastmodified":1694492791,
+    "wof:lastmodified":1695886466,
     "wof:name":"El Fasher",
     "wof:parent_id":85676919,
     "wof:placetype":"county",

--- a/data/109/170/639/7/1091706397.geojson
+++ b/data/109/170/639/7/1091706397.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"SD.ND.ME"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473879997,
     "wof:geomhash":"4e5f0bf47a55440ac346f11a37dd9e3c",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091706397,
-    "wof:lastmodified":1694492843,
+    "wof:lastmodified":1695886287,
     "wof:name":"El Kuma",
     "wof:parent_id":85676919,
     "wof:placetype":"county",

--- a/data/109/170/644/5/1091706445.geojson
+++ b/data/109/170/644/5/1091706445.geojson
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":1091706445,
-    "wof:lastmodified":1694492843,
+    "wof:lastmodified":1695886287,
     "wof:name":"El Ferdous",
     "wof:parent_id":85676875,
     "wof:placetype":"county",

--- a/data/109/170/646/7/1091706467.geojson
+++ b/data/109/170/646/7/1091706467.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"SD.SD.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880000,
     "wof:geomhash":"9efe2f778fb7653cc92e27ad39ff57e5",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091706467,
-    "wof:lastmodified":1694492843,
+    "wof:lastmodified":1695886288,
     "wof:name":"El Radoom",
     "wof:parent_id":85676871,
     "wof:placetype":"county",

--- a/data/109/170/650/9/1091706509.geojson
+++ b/data/109/170/650/9/1091706509.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.BN.ER"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880002,
     "wof:geomhash":"2f9a863ff0fc300d26fcf3c07c09f03b",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091706509,
-    "wof:lastmodified":1694492790,
+    "wof:lastmodified":1695886464,
     "wof:name":"El Roseires",
     "wof:parent_id":85676865,
     "wof:placetype":"county",

--- a/data/109/170/654/1/1091706541.geojson
+++ b/data/109/170/654/1/1091706541.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KN.EN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880003,
     "wof:geomhash":"121ec8a102b394152cb67c28a7515dc9",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091706541,
-    "wof:lastmodified":1694492791,
+    "wof:lastmodified":1695886467,
     "wof:name":"El Nehoud",
     "wof:parent_id":1108805631,
     "wof:placetype":"county",

--- a/data/109/170/656/5/1091706565.geojson
+++ b/data/109/170/656/5/1091706565.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KS.ES"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880005,
     "wof:geomhash":"06d5b71f6500eb63d0437777c22dc06e",
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091706565,
-    "wof:lastmodified":1694492791,
+    "wof:lastmodified":1695886467,
     "wof:name":"El Salam",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/170/658/3/1091706583.geojson
+++ b/data/109/170/658/3/1091706583.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KN.AZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880006,
     "wof:geomhash":"444097a85d33e87f1427e24b45622c23",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091706583,
-    "wof:lastmodified":1694492790,
+    "wof:lastmodified":1695886462,
     "wof:name":"Abu Zabad",
     "wof:parent_id":1108805631,
     "wof:placetype":"county",

--- a/data/109/170/661/1/1091706611.geojson
+++ b/data/109/170/661/1/1091706611.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.BN.ED"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880008,
     "wof:geomhash":"a8c5423e14ed190aa5a75bff2e201a31",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091706611,
-    "wof:lastmodified":1694492790,
+    "wof:lastmodified":1695886462,
     "wof:name":"El Damazine",
     "wof:parent_id":85676865,
     "wof:placetype":"county",

--- a/data/109/170/663/7/1091706637.geojson
+++ b/data/109/170/663/7/1091706637.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.SI.AL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880009,
     "wof:geomhash":"16b66d64b8195438e235c70067189026",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091706637,
-    "wof:lastmodified":1694492791,
+    "wof:lastmodified":1695886467,
     "wof:name":"El Souki",
     "wof:parent_id":85676915,
     "wof:placetype":"county",

--- a/data/109/170/667/3/1091706673.geojson
+++ b/data/109/170/667/3/1091706673.geojson
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":1091706673,
-    "wof:lastmodified":1694492843,
+    "wof:lastmodified":1695886288,
     "wof:name":"El Taweisha",
     "wof:parent_id":85676919,
     "wof:placetype":"county",

--- a/data/109/170/671/7/1091706717.geojson
+++ b/data/109/170/671/7/1091706717.geojson
@@ -62,6 +62,7 @@
     "wof:concordances":{
         "hasc:id":"SD.SD.NY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880012,
     "wof:geomhash":"769143298a4578e9859186d6083767a1",
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1091706717,
-    "wof:lastmodified":1694492395,
+    "wof:lastmodified":1695886319,
     "wof:name":"Gereida",
     "wof:parent_id":85676871,
     "wof:placetype":"county",

--- a/data/109/170/675/7/1091706757.geojson
+++ b/data/109/170/675/7/1091706757.geojson
@@ -92,6 +92,7 @@
     "wof:concordances":{
         "hasc:id":"SD.SD.AD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880014,
     "wof:geomhash":"08e78174072199612b4eb52573293c52",
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091706757,
-    "wof:lastmodified":1694492790,
+    "wof:lastmodified":1695886462,
     "wof:name":"Adila",
     "wof:parent_id":85676875,
     "wof:placetype":"county",

--- a/data/109/170/678/3/1091706783.geojson
+++ b/data/109/170/678/3/1091706783.geojson
@@ -85,6 +85,7 @@
         "hasc:id":"SD.KN.GB",
         "wd:id":"Q10289400"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880015,
     "wof:geomhash":"49725a19c44b313c9bf48469c4aa6aca",
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1091706783,
-    "wof:lastmodified":1694492791,
+    "wof:lastmodified":1695886467,
     "wof:name":"Ghubaysh",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/170/682/9/1091706829.geojson
+++ b/data/109/170/682/9/1091706829.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"SD.GZ.EE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880017,
     "wof:geomhash":"9caef84c6d74b1ea2b358187c3a4d5fd",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1091706829,
-    "wof:lastmodified":1694492790,
+    "wof:lastmodified":1695886464,
     "wof:name":"Eastern El Gezira",
     "wof:parent_id":85676893,
     "wof:placetype":"county",

--- a/data/109/170/687/7/1091706877.geojson
+++ b/data/109/170/687/7/1091706877.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"SD.GZ.WO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880018,
     "wof:geomhash":"60789bd15d5633656ef74c75892c6237",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1091706877,
-    "wof:lastmodified":1694492793,
+    "wof:lastmodified":1695886472,
     "wof:name":"Greater Wad Madani",
     "wof:parent_id":85676893,
     "wof:placetype":"county",

--- a/data/109/170/689/7/1091706897.geojson
+++ b/data/109/170/689/7/1091706897.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KS.AJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880020,
     "wof:geomhash":"3a0da881a206709151350ef395554a98",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091706897,
-    "wof:lastmodified":1694492790,
+    "wof:lastmodified":1695886462,
     "wof:name":"Abu Jubaiha",
     "wof:parent_id":85676923,
     "wof:placetype":"county",

--- a/data/109/170/691/9/1091706919.geojson
+++ b/data/109/170/691/9/1091706919.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1091706919,
-    "wof:lastmodified":1694492848,
+    "wof:lastmodified":1695886300,
     "wof:name":"Habila",
     "wof:parent_id":85676923,
     "wof:placetype":"county",

--- a/data/109/170/694/5/1091706945.geojson
+++ b/data/109/170/694/5/1091706945.geojson
@@ -71,6 +71,7 @@
     "wof:concordances":{
         "hasc:id":"SD.WD.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880023,
     "wof:geomhash":"f9ff871f12128564568791f742a35944",
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1091706945,
-    "wof:lastmodified":1694492792,
+    "wof:lastmodified":1695886468,
     "wof:name":"Habila",
     "wof:parent_id":85676881,
     "wof:placetype":"county",

--- a/data/109/170/697/3/1091706973.geojson
+++ b/data/109/170/697/3/1091706973.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.NO.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880024,
     "wof:geomhash":"66286bafcf9266970ef2217036568f82",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091706973,
-    "wof:lastmodified":1694492396,
+    "wof:lastmodified":1695886319,
     "wof:name":"Halfa",
     "wof:parent_id":85676905,
     "wof:placetype":"county",

--- a/data/109/170/700/7/1091707007.geojson
+++ b/data/109/170/700/7/1091707007.geojson
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":1091707007,
-    "wof:lastmodified":1694492841,
+    "wof:lastmodified":1695886284,
     "wof:name":"Dordeb",
     "wof:parent_id":85676867,
     "wof:placetype":"county",

--- a/data/109/170/705/3/1091707053.geojson
+++ b/data/109/170/705/3/1091707053.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KA.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880028,
     "wof:geomhash":"2b300fe0585b70d83ce9978d45e72321",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091707053,
-    "wof:lastmodified":1694492792,
+    "wof:lastmodified":1695886468,
     "wof:name":"Hamashkoreib",
     "wof:parent_id":85676929,
     "wof:placetype":"county",

--- a/data/109/170/709/5/1091707095.geojson
+++ b/data/109/170/709/5/1091707095.geojson
@@ -94,6 +94,7 @@
     "wof:concordances":{
         "hasc:id":"SD.RS.HY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880029,
     "wof:geomhash":"c17f297c9328629a7d27050b2003ca6a",
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1091707095,
-    "wof:lastmodified":1694492395,
+    "wof:lastmodified":1695886318,
     "wof:name":"Haya",
     "wof:parent_id":85676867,
     "wof:placetype":"county",

--- a/data/109/170/713/5/1091707135.geojson
+++ b/data/109/170/713/5/1091707135.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KH.JA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880031,
     "wof:geomhash":"ff2c810dce93e79fb01504d7a13ee6b4",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1091707135,
-    "wof:lastmodified":1694492792,
+    "wof:lastmodified":1695886468,
     "wof:name":"Jabal Aulia",
     "wof:parent_id":85676889,
     "wof:placetype":"county",

--- a/data/109/170/717/1/1091707171.geojson
+++ b/data/109/170/717/1/1091707171.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.ND.AS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880032,
     "wof:geomhash":"173748b136d601c71bca038888ff0dcb",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091707171,
-    "wof:lastmodified":1694492792,
+    "wof:lastmodified":1695886468,
     "wof:name":"El Sireaf",
     "wof:parent_id":85676919,
     "wof:placetype":"county",

--- a/data/109/170/721/9/1091707219.geojson
+++ b/data/109/170/721/9/1091707219.geojson
@@ -56,6 +56,7 @@
     "wof:concordances":{
         "hasc:id":"SD.WD.KU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880034,
     "wof:geomhash":"86d7b5e969f1839a71a1f7f224c3a8c1",
@@ -68,7 +69,7 @@
         }
     ],
     "wof:id":1091707219,
-    "wof:lastmodified":1694492852,
+    "wof:lastmodified":1695886310,
     "wof:name":"Jebel Moon",
     "wof:parent_id":85676881,
     "wof:placetype":"county",

--- a/data/109/170/724/9/1091707249.geojson
+++ b/data/109/170/724/9/1091707249.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.ND.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880035,
     "wof:geomhash":"bc8d460b8e4571519205c03ac67ab799",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091707249,
-    "wof:lastmodified":1694492792,
+    "wof:lastmodified":1695886468,
     "wof:name":"Kalimendo",
     "wof:parent_id":85676919,
     "wof:placetype":"county",

--- a/data/109/170/727/9/1091707279.geojson
+++ b/data/109/170/727/9/1091707279.geojson
@@ -56,6 +56,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KS.ES"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880037,
     "wof:geomhash":"3a61860c57b0be79c8b8df52a4b8f8a9",
@@ -68,7 +69,7 @@
         }
     ],
     "wof:id":1091707279,
-    "wof:lastmodified":1694492843,
+    "wof:lastmodified":1695886288,
     "wof:name":"El Salam",
     "wof:parent_id":85676871,
     "wof:placetype":"county",

--- a/data/109/170/730/7/1091707307.geojson
+++ b/data/109/170/730/7/1091707307.geojson
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":1091707307,
-    "wof:lastmodified":1694492853,
+    "wof:lastmodified":1695886312,
     "wof:name":"Katayla",
     "wof:parent_id":85676871,
     "wof:placetype":"county",

--- a/data/109/170/731/9/1091707319.geojson
+++ b/data/109/170/731/9/1091707319.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.RN.EM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880040,
     "wof:geomhash":"198e87b98089176d2dbc731313d25c2a",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091707319,
-    "wof:lastmodified":1694492790,
+    "wof:lastmodified":1695886464,
     "wof:name":"El Matammah",
     "wof:parent_id":85676901,
     "wof:placetype":"county",

--- a/data/109/170/736/1/1091707361.geojson
+++ b/data/109/170/736/1/1091707361.geojson
@@ -154,6 +154,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KH.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880042,
     "wof:geomhash":"b2b1d83525a4585f83a56d6a74741aa9",
@@ -166,7 +167,7 @@
         }
     ],
     "wof:id":1091707361,
-    "wof:lastmodified":1694492395,
+    "wof:lastmodified":1695886318,
     "wof:name":"Khartoum North",
     "wof:parent_id":85676889,
     "wof:placetype":"county",

--- a/data/109/170/738/3/1091707383.geojson
+++ b/data/109/170/738/3/1091707383.geojson
@@ -445,6 +445,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KH.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         890441687
     ],
@@ -460,7 +461,7 @@
         }
     ],
     "wof:id":1091707383,
-    "wof:lastmodified":1694492925,
+    "wof:lastmodified":1695886658,
     "wof:name":"Khartoum",
     "wof:parent_id":85676889,
     "wof:placetype":"county",

--- a/data/109/170/738/5/1091707385.geojson
+++ b/data/109/170/738/5/1091707385.geojson
@@ -66,6 +66,7 @@
         "hasc:id":"SD.KA.NB",
         "wd:id":"Q10370728"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880044,
     "wof:geomhash":"98293624a3a850a7de4a3fc9807374ac",
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091707385,
-    "wof:lastmodified":1694492793,
+    "wof:lastmodified":1695886470,
     "wof:name":"Atbara River",
     "wof:parent_id":85676929,
     "wof:placetype":"county",

--- a/data/109/170/738/7/1091707387.geojson
+++ b/data/109/170/738/7/1091707387.geojson
@@ -79,6 +79,7 @@
         "hasc:id":"SD.KA.SE",
         "wd:id":"Q10370728"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880046,
     "wof:geomhash":"a21b55149247e798228d6fa8dddb5491",
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1091707387,
-    "wof:lastmodified":1694492792,
+    "wof:lastmodified":1695886469,
     "wof:name":"Khashm Ghirba",
     "wof:parent_id":85676929,
     "wof:placetype":"county",

--- a/data/109/170/739/9/1091707399.geojson
+++ b/data/109/170/739/9/1091707399.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.WN.EL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880047,
     "wof:geomhash":"35974db9ade33f1cb6bb272a915abca9",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091707399,
-    "wof:lastmodified":1694492791,
+    "wof:lastmodified":1695886467,
     "wof:name":"El Douiem",
     "wof:parent_id":85676909,
     "wof:placetype":"county",

--- a/data/109/170/743/1/1091707431.geojson
+++ b/data/109/170/743/1/1091707431.geojson
@@ -82,6 +82,7 @@
     "wof:concordances":{
         "hasc:id":"SD.WN.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880049,
     "wof:geomhash":"519164435db45b5a4de422e366877c6b",
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1091707431,
-    "wof:lastmodified":1694492925,
+    "wof:lastmodified":1695886658,
     "wof:name":"Kosti",
     "wof:parent_id":85676909,
     "wof:placetype":"county",

--- a/data/109/170/747/7/1091707477.geojson
+++ b/data/109/170/747/7/1091707477.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.WD.KI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880051,
     "wof:geomhash":"fbf760a18948e066b4f436c29bf7cc73",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091707477,
-    "wof:lastmodified":1694492792,
+    "wof:lastmodified":1695886470,
     "wof:name":"Kreinik",
     "wof:parent_id":85676881,
     "wof:placetype":"county",

--- a/data/109/170/752/1/1091707521.geojson
+++ b/data/109/170/752/1/1091707521.geojson
@@ -91,6 +91,7 @@
     "wof:concordances":{
         "hasc:id":"SD.ND.KU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880052,
     "wof:geomhash":"f9fb0d120c4bfee33ba285ff092acd47",
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1091707521,
-    "wof:lastmodified":1694492792,
+    "wof:lastmodified":1695886470,
     "wof:name":"Kutum",
     "wof:parent_id":85676919,
     "wof:placetype":"county",

--- a/data/109/170/752/3/1091707523.geojson
+++ b/data/109/170/752/3/1091707523.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KS.LA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880053,
     "wof:geomhash":"ceddce29b5fe10360fa7673030fa979d",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091707523,
-    "wof:lastmodified":1694492792,
+    "wof:lastmodified":1695886470,
     "wof:name":"Lagawa",
     "wof:parent_id":1108805631,
     "wof:placetype":"county",

--- a/data/109/170/752/9/1091707529.geojson
+++ b/data/109/170/752/9/1091707529.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"SD.SD.NY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880055,
     "wof:geomhash":"80100d797a2b38932e21038d9cb4daf0",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091707529,
-    "wof:lastmodified":1694492865,
+    "wof:lastmodified":1695886346,
     "wof:name":"Marshang",
     "wof:parent_id":85676871,
     "wof:placetype":"county",

--- a/data/109/170/757/5/1091707575.geojson
+++ b/data/109/170/757/5/1091707575.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"SD.SD.NY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880056,
     "wof:geomhash":"d36a5da00ee8b034381fa95489c53b27",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091707575,
-    "wof:lastmodified":1694492832,
+    "wof:lastmodified":1695886263,
     "wof:name":"Bielel",
     "wof:parent_id":85676871,
     "wof:placetype":"county",

--- a/data/109/170/760/9/1091707609.geojson
+++ b/data/109/170/760/9/1091707609.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"SD.SD.NY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880058,
     "wof:geomhash":"16eeefe1477c8df48ea363b4ae7d8299",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091707609,
-    "wof:lastmodified":1694492870,
+    "wof:lastmodified":1695886363,
     "wof:name":"Nyala North",
     "wof:parent_id":85676871,
     "wof:placetype":"county",

--- a/data/109/170/761/1/1091707611.geojson
+++ b/data/109/170/761/1/1091707611.geojson
@@ -178,6 +178,7 @@
     "wof:concordances":{
         "hasc:id":"SD.SD.NY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880059,
     "wof:geomhash":"ca1401dce575e144b3be072091e7849c",
@@ -190,7 +191,7 @@
         }
     ],
     "wof:id":1091707611,
-    "wof:lastmodified":1694492395,
+    "wof:lastmodified":1695886319,
     "wof:name":"Nyala",
     "wof:parent_id":85676871,
     "wof:placetype":"county",

--- a/data/109/170/762/1/1091707621.geojson
+++ b/data/109/170/762/1/1091707621.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.GD.QN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880061,
     "wof:geomhash":"2e5b03343abee32c38cf6b68d2406eba",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091707621,
-    "wof:lastmodified":1694492793,
+    "wof:lastmodified":1695886471,
     "wof:name":"Qala El Nahal",
     "wof:parent_id":85676897,
     "wof:placetype":"county",

--- a/data/109/170/766/9/1091707669.geojson
+++ b/data/109/170/766/9/1091707669.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.GD.CG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880062,
     "wof:geomhash":"ee57d5c5879b59b69e3e2400cd884ba4",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091707669,
-    "wof:lastmodified":1694492792,
+    "wof:lastmodified":1695886470,
     "wof:name":"Middle Gedaref",
     "wof:parent_id":85676897,
     "wof:placetype":"county",

--- a/data/109/170/771/5/1091707715.geojson
+++ b/data/109/170/771/5/1091707715.geojson
@@ -58,6 +58,7 @@
     "wof:concordances":{
         "hasc:id":"SD.GD.GC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880064,
     "wof:geomhash":"53732e0c1fec7150bb399d01d752fe3a",
@@ -70,7 +71,7 @@
         }
     ],
     "wof:id":1091707715,
-    "wof:lastmodified":1694492925,
+    "wof:lastmodified":1695886658,
     "wof:name":"Gedaref",
     "wof:parent_id":85676897,
     "wof:placetype":"county",

--- a/data/109/170/775/3/1091707753.geojson
+++ b/data/109/170/775/3/1091707753.geojson
@@ -121,6 +121,7 @@
     "wof:concordances":{
         "hasc:id":"SD.WN.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880065,
     "wof:geomhash":"3746ec4f22e6705fe22c80b303cde6d9",
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":1091707753,
-    "wof:lastmodified":1694492396,
+    "wof:lastmodified":1695886319,
     "wof:name":"Rabak",
     "wof:parent_id":85676909,
     "wof:placetype":"county",

--- a/data/109/170/777/9/1091707779.geojson
+++ b/data/109/170/777/9/1091707779.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"SD.GZ.EM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880067,
     "wof:geomhash":"6571059a879447fb6e35ea5483c88df9",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1091707779,
-    "wof:lastmodified":1694492792,
+    "wof:lastmodified":1695886468,
     "wof:name":"El Manageel",
     "wof:parent_id":85676893,
     "wof:placetype":"county",

--- a/data/109/170/781/5/1091707815.geojson
+++ b/data/109/170/781/5/1091707815.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.WN.EJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880068,
     "wof:geomhash":"16dad08f054c24d45f4e365d6a24c267",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091707815,
-    "wof:lastmodified":1694492791,
+    "wof:lastmodified":1695886467,
     "wof:name":"El Jabalian",
     "wof:parent_id":85676909,
     "wof:placetype":"county",

--- a/data/109/170/784/1/1091707841.geojson
+++ b/data/109/170/784/1/1091707841.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.WD.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880070,
     "wof:geomhash":"1cdbb7d96ac1dfaf689873eff58a8560",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091707841,
-    "wof:lastmodified":1694492792,
+    "wof:lastmodified":1695886470,
     "wof:name":"Mukjar",
     "wof:parent_id":85676885,
     "wof:placetype":"county",

--- a/data/109/170/788/5/1091707885.geojson
+++ b/data/109/170/788/5/1091707885.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"SD.SD.RB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880071,
     "wof:geomhash":"8ae484f813ecafee14836a662f3631b4",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1091707885,
-    "wof:lastmodified":1694492793,
+    "wof:lastmodified":1695886471,
     "wof:name":"Rahad El Berdi",
     "wof:parent_id":85676871,
     "wof:placetype":"county",

--- a/data/109/170/792/5/1091707925.geojson
+++ b/data/109/170/792/5/1091707925.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"SD.SD.EF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880072,
     "wof:geomhash":"4fcb6093340089492ade8ddbfa710994",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1091707925,
-    "wof:lastmodified":1694492791,
+    "wof:lastmodified":1695886467,
     "wof:name":"Ed El Fursan",
     "wof:parent_id":85676871,
     "wof:placetype":"county",

--- a/data/109/170/796/9/1091707969.geojson
+++ b/data/109/170/796/9/1091707969.geojson
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":1091707969,
-    "wof:lastmodified":1694492792,
+    "wof:lastmodified":1695886468,
     "wof:name":"Heiban",
     "wof:parent_id":85676923,
     "wof:placetype":"county",

--- a/data/109/170/799/5/1091707995.geojson
+++ b/data/109/170/799/5/1091707995.geojson
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":1091707995,
-    "wof:lastmodified":1694492880,
+    "wof:lastmodified":1695886392,
     "wof:name":"Reif Ashargi",
     "wof:parent_id":85676923,
     "wof:placetype":"county",

--- a/data/109/170/799/7/1091707997.geojson
+++ b/data/109/170/799/7/1091707997.geojson
@@ -71,6 +71,7 @@
     "wof:concordances":{
         "hasc:id":"SD.SD.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880077,
     "wof:geomhash":"53a12694ab825a33adc2786cc71689a7",
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1091707997,
-    "wof:lastmodified":1694492792,
+    "wof:lastmodified":1695886469,
     "wof:name":"Kass",
     "wof:parent_id":85676871,
     "wof:placetype":"county",

--- a/data/109/170/799/9/1091707999.geojson
+++ b/data/109/170/799/9/1091707999.geojson
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":1091707999,
-    "wof:lastmodified":1694492880,
+    "wof:lastmodified":1695886392,
     "wof:name":"Rokoro",
     "wof:parent_id":85676885,
     "wof:placetype":"county",

--- a/data/109/170/810/5/1091708105.geojson
+++ b/data/109/170/810/5/1091708105.geojson
@@ -160,6 +160,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KA.KC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880080,
     "wof:geomhash":"30e33f60bb87cd7841ee82a0d11c6c59",
@@ -172,7 +173,7 @@
         }
     ],
     "wof:id":1091708105,
-    "wof:lastmodified":1694492925,
+    "wof:lastmodified":1695886658,
     "wof:name":"Kassala",
     "wof:parent_id":85676929,
     "wof:placetype":"county",

--- a/data/109/170/814/9/1091708149.geojson
+++ b/data/109/170/814/9/1091708149.geojson
@@ -79,6 +79,7 @@
         "hasc:id":"SD.KA.KR",
         "wd:id":"Q10370728"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880087,
     "wof:geomhash":"f651d4f3aaa5ad983bdb02e03c15020f",
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1091708149,
-    "wof:lastmodified":1694492792,
+    "wof:lastmodified":1695886469,
     "wof:name":"Rural Kassala",
     "wof:parent_id":85676929,
     "wof:placetype":"county",

--- a/data/109/170/819/3/1091708193.geojson
+++ b/data/109/170/819/3/1091708193.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.ND.SO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880088,
     "wof:geomhash":"d70142b56ad7d902ea8770b10b1a20cc",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091708193,
-    "wof:lastmodified":1694492793,
+    "wof:lastmodified":1695886471,
     "wof:name":"Saraf Omra",
     "wof:parent_id":85676919,
     "wof:placetype":"county",

--- a/data/109/170/821/5/1091708215.geojson
+++ b/data/109/170/821/5/1091708215.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"SD.WD.NE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880090,
     "wof:geomhash":"89c2087305dc22b93056e08a86f0255e",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1091708215,
-    "wof:lastmodified":1694492792,
+    "wof:lastmodified":1695886470,
     "wof:name":"Nertiti",
     "wof:parent_id":85676885,
     "wof:placetype":"county",

--- a/data/109/170/825/7/1091708257.geojson
+++ b/data/109/170/825/7/1091708257.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.SI.ES"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880091,
     "wof:geomhash":"080def8c125dd5196ddf4f0228da5aed",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091708257,
-    "wof:lastmodified":1694492791,
+    "wof:lastmodified":1695886467,
     "wof:name":"Eastern Sennar",
     "wof:parent_id":85676915,
     "wof:placetype":"county",

--- a/data/109/170/829/9/1091708299.geojson
+++ b/data/109/170/829/9/1091708299.geojson
@@ -163,6 +163,7 @@
     "wof:concordances":{
         "hasc:id":"SD.SI.SI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880093,
     "wof:geomhash":"cbb82af97d63b87a345f1f14a39744fd",
@@ -175,7 +176,7 @@
         }
     ],
     "wof:id":1091708299,
-    "wof:lastmodified":1694492925,
+    "wof:lastmodified":1695886658,
     "wof:name":"Sennar",
     "wof:parent_id":85676915,
     "wof:placetype":"county",

--- a/data/109/170/833/7/1091708337.geojson
+++ b/data/109/170/833/7/1091708337.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"SD.SD.NY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880094,
     "wof:geomhash":"4165c9b692e35e3e8d2b2cd2cb8c5644",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091708337,
-    "wof:lastmodified":1694492883,
+    "wof:lastmodified":1695886397,
     "wof:name":"Sharg Jabel Marra",
     "wof:parent_id":85676871,
     "wof:placetype":"county",

--- a/data/109/170/837/7/1091708377.geojson
+++ b/data/109/170/837/7/1091708377.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.GZ.EK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880096,
     "wof:geomhash":"b97ccffbf7bea61a280f9651ea79da37",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091708377,
-    "wof:lastmodified":1694492791,
+    "wof:lastmodified":1695886467,
     "wof:name":"El Kamleen",
     "wof:parent_id":85676893,
     "wof:placetype":"county",

--- a/data/109/170/842/5/1091708425.geojson
+++ b/data/109/170/842/5/1091708425.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KH.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880097,
     "wof:geomhash":"01420eed63b0a6fc7fb5202ee75d2546",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091708425,
-    "wof:lastmodified":1694492793,
+    "wof:lastmodified":1695886471,
     "wof:name":"Sharq El Nile",
     "wof:parent_id":85676889,
     "wof:placetype":"county",

--- a/data/109/170/847/1/1091708471.geojson
+++ b/data/109/170/847/1/1091708471.geojson
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":1091708471,
-    "wof:lastmodified":1694492858,
+    "wof:lastmodified":1695886326,
     "wof:name":"Kubum",
     "wof:parent_id":85676871,
     "wof:placetype":"county",

--- a/data/109/170/851/7/1091708517.geojson
+++ b/data/109/170/851/7/1091708517.geojson
@@ -56,6 +56,7 @@
     "wof:concordances":{
         "hasc:id":"SD.WD.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880101,
     "wof:geomhash":"52225df66fa1566ed9eb5dff9e603a23",
@@ -68,7 +69,7 @@
         }
     ],
     "wof:id":1091708517,
-    "wof:lastmodified":1694492883,
+    "wof:lastmodified":1695886397,
     "wof:name":"Shattai",
     "wof:parent_id":85676871,
     "wof:placetype":"county",

--- a/data/109/170/856/3/1091708563.geojson
+++ b/data/109/170/856/3/1091708563.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"SD.SD.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880102,
     "wof:geomhash":"da56998119066bb4b94b619e3c263ef7",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1091708563,
-    "wof:lastmodified":1694492793,
+    "wof:lastmodified":1695886471,
     "wof:name":"Sheiria",
     "wof:parent_id":85676875,
     "wof:placetype":"county",

--- a/data/109/170/861/5/1091708615.geojson
+++ b/data/109/170/861/5/1091708615.geojson
@@ -88,6 +88,7 @@
     "wof:concordances":{
         "hasc:id":"SD.SI.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880103,
     "wof:geomhash":"998a88fbeff14dcab843cd5e4cb1fed1",
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1091708615,
-    "wof:lastmodified":1694492395,
+    "wof:lastmodified":1695886318,
     "wof:name":"Singa",
     "wof:parent_id":85676915,
     "wof:placetype":"county",

--- a/data/109/170/865/1/1091708651.geojson
+++ b/data/109/170/865/1/1091708651.geojson
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":1091708651,
-    "wof:lastmodified":1694492824,
+    "wof:lastmodified":1695886246,
     "wof:name":"Abu Houjar",
     "wof:parent_id":85676915,
     "wof:placetype":"county",

--- a/data/109/170/869/5/1091708695.geojson
+++ b/data/109/170/869/5/1091708695.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"SD.GZ.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880106,
     "wof:geomhash":"f6aeb76159b2e275fe25818d2b9aa62b",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1091708695,
-    "wof:lastmodified":1694492790,
+    "wof:lastmodified":1695886464,
     "wof:name":"Southern El Gezira",
     "wof:parent_id":85676893,
     "wof:placetype":"county",

--- a/data/109/170/872/3/1091708723.geojson
+++ b/data/109/170/872/3/1091708723.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"SD.SD.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880108,
     "wof:geomhash":"1a209444a8b55c7f1f4786d9122b3345",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091708723,
-    "wof:lastmodified":1694492887,
+    "wof:lastmodified":1695886406,
     "wof:name":"Sunta",
     "wof:parent_id":85676871,
     "wof:placetype":"county",

--- a/data/109/170/872/5/1091708725.geojson
+++ b/data/109/170/872/5/1091708725.geojson
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":1091708725,
-    "wof:lastmodified":1694492889,
+    "wof:lastmodified":1695886411,
     "wof:name":"Tawilla",
     "wof:parent_id":85676919,
     "wof:placetype":"county",

--- a/data/109/170/872/7/1091708727.geojson
+++ b/data/109/170/872/7/1091708727.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.WN.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880111,
     "wof:geomhash":"4dec112d12687b9cf25a47056203ac00",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091708727,
-    "wof:lastmodified":1694492793,
+    "wof:lastmodified":1695886472,
     "wof:name":"Tendalti",
     "wof:parent_id":85676909,
     "wof:placetype":"county",

--- a/data/109/170/873/3/1091708733.geojson
+++ b/data/109/170/873/3/1091708733.geojson
@@ -115,6 +115,7 @@
     "wof:concordances":{
         "hasc:id":"SD.RS.TO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880112,
     "wof:geomhash":"e6da032cfbc9dd4a7049aeff64ee9820",
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1091708733,
-    "wof:lastmodified":1694492925,
+    "wof:lastmodified":1695886658,
     "wof:name":"Tokar",
     "wof:parent_id":85676867,
     "wof:placetype":"county",

--- a/data/109/170/877/9/1091708779.geojson
+++ b/data/109/170/877/9/1091708779.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.SD.TU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880114,
     "wof:geomhash":"f0b847a7341f050b790aac27d3473450",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091708779,
-    "wof:lastmodified":1694492793,
+    "wof:lastmodified":1695886472,
     "wof:name":"Tullus",
     "wof:parent_id":85676871,
     "wof:placetype":"county",

--- a/data/109/170/880/3/1091708803.geojson
+++ b/data/109/170/880/3/1091708803.geojson
@@ -106,6 +106,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KH.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880115,
     "wof:geomhash":"2bd373c47ad7dd2044bea3fd9c80a038",
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1091708803,
-    "wof:lastmodified":1694492792,
+    "wof:lastmodified":1695886469,
     "wof:name":"Karari",
     "wof:parent_id":85676889,
     "wof:placetype":"county",

--- a/data/109/170/885/3/1091708853.geojson
+++ b/data/109/170/885/3/1091708853.geojson
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":1091708853,
-    "wof:lastmodified":1694492890,
+    "wof:lastmodified":1695886415,
     "wof:name":"Um Durman",
     "wof:parent_id":85676889,
     "wof:placetype":"county",

--- a/data/109/170/889/5/1091708895.geojson
+++ b/data/109/170/889/5/1091708895.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"SD.GZ.UA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880118,
     "wof:geomhash":"15d9cdceb9ff7664d53805d3ebe260aa",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1091708895,
-    "wof:lastmodified":1694492793,
+    "wof:lastmodified":1695886472,
     "wof:name":"Um El Qura",
     "wof:parent_id":85676893,
     "wof:placetype":"county",

--- a/data/109/170/893/1/1091708931.geojson
+++ b/data/109/170/893/1/1091708931.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KS.ES"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880119,
     "wof:geomhash":"00794f0b2d2020b0d8fd0f871b55353b",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091708931,
-    "wof:lastmodified":1694492843,
+    "wof:lastmodified":1695886289,
     "wof:name":"El Salam",
     "wof:parent_id":85676909,
     "wof:placetype":"county",

--- a/data/109/170/896/1/1091708961.geojson
+++ b/data/109/170/896/1/1091708961.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KN.UR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880121,
     "wof:geomhash":"3302caaafa77782b0b8635e483b0d7e7",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091708961,
-    "wof:lastmodified":1694492793,
+    "wof:lastmodified":1695886472,
     "wof:name":"Um Rawaba",
     "wof:parent_id":85676925,
     "wof:placetype":"county",

--- a/data/109/170/896/3/1091708963.geojson
+++ b/data/109/170/896/3/1091708963.geojson
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":1091708963,
-    "wof:lastmodified":1694492891,
+    "wof:lastmodified":1695886417,
     "wof:name":"Umm Durein",
     "wof:parent_id":85676923,
     "wof:placetype":"county",

--- a/data/109/170/897/5/1091708975.geojson
+++ b/data/109/170/897/5/1091708975.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KN.SO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880124,
     "wof:geomhash":"8661ec88bb962be5f86b0579b0ecaa55",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091708975,
-    "wof:lastmodified":1694492793,
+    "wof:lastmodified":1695886471,
     "wof:name":"Sodari",
     "wof:parent_id":85676925,
     "wof:placetype":"county",

--- a/data/109/170/900/5/1091709005.geojson
+++ b/data/109/170/900/5/1091709005.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.ND.UK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880126,
     "wof:geomhash":"9570485d602c93cedfd55ed827079745",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091709005,
-    "wof:lastmodified":1694492793,
+    "wof:lastmodified":1695886472,
     "wof:name":"Umm Keddada",
     "wof:parent_id":85676919,
     "wof:placetype":"county",

--- a/data/109/170/905/1/1091709051.geojson
+++ b/data/109/170/905/1/1091709051.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.WN.UR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880127,
     "wof:geomhash":"28ae6ba7f3696e93a3e6110f5c0e1e74",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091709051,
-    "wof:lastmodified":1694492793,
+    "wof:lastmodified":1695886472,
     "wof:name":"Umm Ramtta",
     "wof:parent_id":85676909,
     "wof:placetype":"county",

--- a/data/109/170/909/7/1091709097.geojson
+++ b/data/109/170/909/7/1091709097.geojson
@@ -79,6 +79,7 @@
         "hasc:id":"SD.KA.WH",
         "wd:id":"Q10370728"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880128,
     "wof:geomhash":"e33b1f17b2f8b3dc19a4190d2ea34b63",
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1091709097,
-    "wof:lastmodified":1694492793,
+    "wof:lastmodified":1695886472,
     "wof:name":"Wad El Helew",
     "wof:parent_id":85676929,
     "wof:placetype":"county",

--- a/data/109/170/913/3/1091709133.geojson
+++ b/data/109/170/913/3/1091709133.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KA.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880130,
     "wof:geomhash":"205c6957f54811803848901b3d3e8cac",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091709133,
-    "wof:lastmodified":1694492793,
+    "wof:lastmodified":1695886471,
     "wof:name":"Telkok",
     "wof:parent_id":85676929,
     "wof:placetype":"county",

--- a/data/109/170/917/7/1091709177.geojson
+++ b/data/109/170/917/7/1091709177.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"SD.GD.ES"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880131,
     "wof:geomhash":"4a101ac09ee24f22e43db118dcc12ac2",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091709177,
-    "wof:lastmodified":1694492893,
+    "wof:lastmodified":1695886422,
     "wof:name":"Western El Galabat",
     "wof:parent_id":85676897,
     "wof:placetype":"county",

--- a/data/109/170/922/3/1091709223.geojson
+++ b/data/109/170/922/3/1091709223.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.GD.ER"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880133,
     "wof:geomhash":"ef1fffa220ca3e5fdf3b7e14a9c69d9f",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091709223,
-    "wof:lastmodified":1694492792,
+    "wof:lastmodified":1695886468,
     "wof:name":"El Rahad",
     "wof:parent_id":85676897,
     "wof:placetype":"county",

--- a/data/109/170/926/9/1091709269.geojson
+++ b/data/109/170/926/9/1091709269.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KA.NB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880134,
     "wof:geomhash":"d6c9e7f923596257b34ff248c4025045",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091709269,
-    "wof:lastmodified":1694492893,
+    "wof:lastmodified":1695886422,
     "wof:name":"Western Kassala",
     "wof:parent_id":85676929,
     "wof:placetype":"county",

--- a/data/109/170/930/3/1091709303.geojson
+++ b/data/109/170/930/3/1091709303.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KA.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880135,
     "wof:geomhash":"92e8a4c3e5d14e7bc294a63dc68fc718",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091709303,
-    "wof:lastmodified":1694492793,
+    "wof:lastmodified":1695886471,
     "wof:name":"North Delta",
     "wof:parent_id":85676929,
     "wof:placetype":"county",

--- a/data/109/170/934/9/1091709349.geojson
+++ b/data/109/170/934/9/1091709349.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"SD.SD.NY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880137,
     "wof:geomhash":"ca0f4fbfd25e7761da6c2e49a1f320ea",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091709349,
-    "wof:lastmodified":1694492895,
+    "wof:lastmodified":1695886427,
     "wof:name":"Yassin",
     "wof:parent_id":85676875,
     "wof:placetype":"county",

--- a/data/109/170/937/5/1091709375.geojson
+++ b/data/109/170/937/5/1091709375.geojson
@@ -85,6 +85,7 @@
     "wof:concordances":{
         "hasc:id":"SD.WD.ZA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880138,
     "wof:geomhash":"28b398040fa21ca62b5dbeb3be18b812",
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1091709375,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886473,
     "wof:name":"Zalingei",
     "wof:parent_id":85676885,
     "wof:placetype":"county",

--- a/data/109/170/937/7/1091709377.geojson
+++ b/data/109/170/937/7/1091709377.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.NO.AD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880140,
     "wof:geomhash":"897799de1ec1276f1b93c80a081ae1ef",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091709377,
-    "wof:lastmodified":1694492790,
+    "wof:lastmodified":1695886463,
     "wof:name":"Al Daba",
     "wof:parent_id":85676905,
     "wof:placetype":"county",

--- a/data/109/170/937/9/1091709379.geojson
+++ b/data/109/170/937/9/1091709379.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"SD.ND.KU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880142,
     "wof:geomhash":"e0edb853e91b1dab6beac5e42c84deb5",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091709379,
-    "wof:lastmodified":1694492890,
+    "wof:lastmodified":1695886415,
     "wof:name":"Um Buru",
     "wof:parent_id":85676919,
     "wof:placetype":"county",

--- a/data/109/170/939/5/1091709395.geojson
+++ b/data/109/170/939/5/1091709395.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KN.GE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880143,
     "wof:geomhash":"368c80adc3b54c102b1c56e674d502a5",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091709395,
-    "wof:lastmodified":1694492792,
+    "wof:lastmodified":1695886469,
     "wof:name":"Jebrat El Sheikh",
     "wof:parent_id":85676925,
     "wof:placetype":"county",

--- a/data/109/170/939/9/1091709399.geojson
+++ b/data/109/170/939/9/1091709399.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.BN.GI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880145,
     "wof:geomhash":"8f069c9cade4bffab05266cb5539b7be",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091709399,
-    "wof:lastmodified":1694492792,
+    "wof:lastmodified":1695886468,
     "wof:name":"Geissan",
     "wof:parent_id":85676865,
     "wof:placetype":"county",

--- a/data/109/170/947/1/1091709471.geojson
+++ b/data/109/170/947/1/1091709471.geojson
@@ -108,6 +108,7 @@
     "wof:concordances":{
         "hasc:id":"SD.RS.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880146,
     "wof:geomhash":"62012c8e25cb0e6e6ae4835031809383",
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1091709471,
-    "wof:lastmodified":1694492395,
+    "wof:lastmodified":1695886318,
     "wof:name":"Halayeb",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/170/952/1/1091709521.geojson
+++ b/data/109/170/952/1/1091709521.geojson
@@ -193,6 +193,7 @@
     "wof:concordances":{
         "hasc:id":"SD.RS.PS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880149,
     "wof:geomhash":"cb47a722beb16d455e4bdc8f04fb3714",
@@ -205,7 +206,7 @@
         }
     ],
     "wof:id":1091709521,
-    "wof:lastmodified":1694492395,
+    "wof:lastmodified":1695886318,
     "wof:name":"Port Sudan",
     "wof:parent_id":85676867,
     "wof:placetype":"county",

--- a/data/109/170/954/7/1091709547.geojson
+++ b/data/109/170/954/7/1091709547.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"SD.WD.SI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880150,
     "wof:geomhash":"9ad53d0d400f9f55799c8ec144f0e78a",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1091709547,
-    "wof:lastmodified":1694492793,
+    "wof:lastmodified":1695886472,
     "wof:name":"Sirba",
     "wof:parent_id":85676881,
     "wof:placetype":"county",

--- a/data/109/170/958/9/1091709589.geojson
+++ b/data/109/170/958/9/1091709589.geojson
@@ -74,6 +74,7 @@
     "wof:concordances":{
         "hasc:id":"SD.WD.WS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880151,
     "wof:geomhash":"ba0978972023ae55ce0762289607c33e",
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091709589,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886473,
     "wof:name":"Wadi Salih",
     "wof:parent_id":85676885,
     "wof:placetype":"county",

--- a/data/109/170/963/5/1091709635.geojson
+++ b/data/109/170/963/5/1091709635.geojson
@@ -100,6 +100,7 @@
     "wof:concordances":{
         "hasc:id":"SD.BN.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880153,
     "wof:geomhash":"be46406e912e7ca516ac56e44306e706",
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1091709635,
-    "wof:lastmodified":1694492791,
+    "wof:lastmodified":1695886465,
     "wof:name":"Bau",
     "wof:parent_id":85676865,
     "wof:placetype":"county",

--- a/data/109/170/967/7/1091709677.geojson
+++ b/data/109/170/967/7/1091709677.geojson
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":1091709677,
-    "wof:lastmodified":1694492825,
+    "wof:lastmodified":1695886248,
     "wof:name":"Al Qoz",
     "wof:parent_id":85676923,
     "wof:placetype":"county",

--- a/data/109/170/973/7/1091709737.geojson
+++ b/data/109/170/973/7/1091709737.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KS.LA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880157,
     "wof:geomhash":"c6e86ececf4c5a3e2fb799e492c49f46",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091709737,
-    "wof:lastmodified":1694492825,
+    "wof:lastmodified":1695886248,
     "wof:name":"Al Sunut",
     "wof:parent_id":1108805631,
     "wof:placetype":"county",

--- a/data/109/170/978/1/1091709781.geojson
+++ b/data/109/170/978/1/1091709781.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.BN.TD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880158,
     "wof:geomhash":"b5a392af98f3dbe8e3167ec9b974aa34",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091709781,
-    "wof:lastmodified":1694492790,
+    "wof:lastmodified":1695886464,
     "wof:name":"Al Tadamon",
     "wof:parent_id":85676865,
     "wof:placetype":"county",

--- a/data/109/170/981/3/1091709813.geojson
+++ b/data/109/170/981/3/1091709813.geojson
@@ -140,6 +140,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KN.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880160,
     "wof:geomhash":"820f57c4e9fe16f7dce36b6fad5fd318",
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":1091709813,
-    "wof:lastmodified":1694492396,
+    "wof:lastmodified":1695886319,
     "wof:name":"Bara",
     "wof:parent_id":85676925,
     "wof:placetype":"county",

--- a/data/109/170/986/3/1091709863.geojson
+++ b/data/109/170/986/3/1091709863.geojson
@@ -80,6 +80,7 @@
     "wof:concordances":{
         "hasc:id":"SD.RN.BE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880161,
     "wof:geomhash":"410275f716d7e2cb3d3da0766b2385b2",
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1091709863,
-    "wof:lastmodified":1694492791,
+    "wof:lastmodified":1695886465,
     "wof:name":"Barbar",
     "wof:parent_id":85676901,
     "wof:placetype":"county",

--- a/data/109/170/991/1/1091709911.geojson
+++ b/data/109/170/991/1/1091709911.geojson
@@ -169,6 +169,7 @@
     "wof:concordances":{
         "hasc:id":"SD.RN.AT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880163,
     "wof:geomhash":"3f2760328926f73ac20b86ae7dc04a73",
@@ -181,7 +182,7 @@
         }
     ],
     "wof:id":1091709911,
-    "wof:lastmodified":1694492925,
+    "wof:lastmodified":1695886658,
     "wof:name":"Atbara",
     "wof:parent_id":85676901,
     "wof:placetype":"county",

--- a/data/109/170/995/5/1091709955.geojson
+++ b/data/109/170/995/5/1091709955.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"SD.GD.ES"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880164,
     "wof:geomhash":"6363fb9b5355cac6483d01022d10fa5f",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091709955,
-    "wof:lastmodified":1694492843,
+    "wof:lastmodified":1695886287,
     "wof:name":"El Quresha",
     "wof:parent_id":85676897,
     "wof:placetype":"county",

--- a/data/109/170/997/7/1091709977.geojson
+++ b/data/109/170/997/7/1091709977.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1091709977,
-    "wof:lastmodified":1694492791,
+    "wof:lastmodified":1695886466,
     "wof:name":"Dilling",
     "wof:parent_id":85676923,
     "wof:placetype":"county",

--- a/data/109/171/002/3/1091710023.geojson
+++ b/data/109/171/002/3/1091710023.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"SD.GD.ES"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880167,
     "wof:geomhash":"3497409593b1c6a4ad6059ff3d1d69cb",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091710023,
-    "wof:lastmodified":1694492843,
+    "wof:lastmodified":1695886287,
     "wof:name":"Eastern El Galabat",
     "wof:parent_id":85676897,
     "wof:placetype":"county",

--- a/data/109/171/006/9/1091710069.geojson
+++ b/data/109/171/006/9/1091710069.geojson
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":1091710069,
-    "wof:lastmodified":1694492843,
+    "wof:lastmodified":1695886287,
     "wof:name":"El Abassiya",
     "wof:parent_id":85676923,
     "wof:placetype":"county",

--- a/data/109/171/009/9/1091710099.geojson
+++ b/data/109/171/009/9/1091710099.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.SI.EL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880170,
     "wof:geomhash":"a1623afd432c5549c4c726a1ed1da019",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091710099,
-    "wof:lastmodified":1694492791,
+    "wof:lastmodified":1695886466,
     "wof:name":"El Dali",
     "wof:parent_id":85676915,
     "wof:placetype":"county",

--- a/data/109/171/014/9/1091710149.geojson
+++ b/data/109/171/014/9/1091710149.geojson
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":1091710149,
-    "wof:lastmodified":1694492844,
+    "wof:lastmodified":1695886291,
     "wof:name":"Foro Baranga",
     "wof:parent_id":85676881,
     "wof:placetype":"county",

--- a/data/109/171/018/9/1091710189.geojson
+++ b/data/109/171/018/9/1091710189.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.WD.AZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880173,
     "wof:geomhash":"d790a5779e3e32db1e41dd825c2ff0da",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091710189,
-    "wof:lastmodified":1694492791,
+    "wof:lastmodified":1695886466,
     "wof:name":"Azum",
     "wof:parent_id":85676885,
     "wof:placetype":"county",

--- a/data/109/171/022/7/1091710227.geojson
+++ b/data/109/171/022/7/1091710227.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KA.NB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880174,
     "wof:geomhash":"1c3fdde2be0011947209ec874e74c14c",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091710227,
-    "wof:lastmodified":1694492848,
+    "wof:lastmodified":1695886300,
     "wof:name":"Halfa El Jadeeda",
     "wof:parent_id":85676929,
     "wof:placetype":"county",

--- a/data/109/171/027/5/1091710275.geojson
+++ b/data/109/171/027/5/1091710275.geojson
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":1091710275,
-    "wof:lastmodified":1694492825,
+    "wof:lastmodified":1695886247,
     "wof:name":"Al Buram",
     "wof:parent_id":85676923,
     "wof:placetype":"county",

--- a/data/109/171/032/1/1091710321.geojson
+++ b/data/109/171/032/1/1091710321.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KS.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880178,
     "wof:geomhash":"b18dc719cd37eb2c367dcccf96bcae58",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1091710321,
-    "wof:lastmodified":1694492925,
+    "wof:lastmodified":1695886658,
     "wof:name":"Kadugli",
     "wof:parent_id":85676923,
     "wof:placetype":"county",

--- a/data/109/171/036/7/1091710367.geojson
+++ b/data/109/171/036/7/1091710367.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.ND.KE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880179,
     "wof:geomhash":"8e174d4eec76e3e6f297c4433a2c9dc2",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091710367,
-    "wof:lastmodified":1694492792,
+    "wof:lastmodified":1695886469,
     "wof:name":"Kebkabiya",
     "wof:parent_id":85676919,
     "wof:placetype":"county",

--- a/data/109/171/038/3/1091710383.geojson
+++ b/data/109/171/038/3/1091710383.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"SD.ND.KU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880180,
     "wof:geomhash":"9c952081ad6a007aadd86399ebbbe7dc",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091710383,
-    "wof:lastmodified":1694492843,
+    "wof:lastmodified":1695886289,
     "wof:name":"El Tina",
     "wof:parent_id":85676919,
     "wof:placetype":"county",

--- a/data/109/171/042/7/1091710427.geojson
+++ b/data/109/171/042/7/1091710427.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.ND.ME"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880182,
     "wof:geomhash":"091d22a8f97337f3a8bf515a1847692a",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091710427,
-    "wof:lastmodified":1694492793,
+    "wof:lastmodified":1695886470,
     "wof:name":"Mellit",
     "wof:parent_id":85676919,
     "wof:placetype":"county",

--- a/data/109/171/047/1/1091710471.geojson
+++ b/data/109/171/047/1/1091710471.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.NO.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880183,
     "wof:geomhash":"a059617c917ff47a4f7aa668989c30c8",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091710471,
-    "wof:lastmodified":1694492793,
+    "wof:lastmodified":1695886470,
     "wof:name":"Merawi",
     "wof:parent_id":85676905,
     "wof:placetype":"county",

--- a/data/109/171/050/1/1091710501.geojson
+++ b/data/109/171/050/1/1091710501.geojson
@@ -56,6 +56,7 @@
     "wof:concordances":{
         "hasc:id":"SD.SD.NY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880185,
     "wof:geomhash":"782c156fce202ba48c5203ebc980ac05",
@@ -68,7 +69,7 @@
         }
     ],
     "wof:id":1091710501,
-    "wof:lastmodified":1694492869,
+    "wof:lastmodified":1695886360,
     "wof:name":"Niteaga",
     "wof:parent_id":85676871,
     "wof:placetype":"county",

--- a/data/109/171/054/7/1091710547.geojson
+++ b/data/109/171/054/7/1091710547.geojson
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":1091710547,
-    "wof:lastmodified":1694492880,
+    "wof:lastmodified":1695886390,
     "wof:name":"Rashad",
     "wof:parent_id":85676923,
     "wof:placetype":"county",

--- a/data/109/171/059/5/1091710595.geojson
+++ b/data/109/171/059/5/1091710595.geojson
@@ -115,6 +115,7 @@
     "wof:concordances":{
         "hasc:id":"SD.RN.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880188,
     "wof:geomhash":"b7da1601177a2f0be6d05821d9851899",
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1091710595,
-    "wof:lastmodified":1694492925,
+    "wof:lastmodified":1695886658,
     "wof:name":"Shendi",
     "wof:parent_id":85676901,
     "wof:placetype":"county",

--- a/data/109/171/063/9/1091710639.geojson
+++ b/data/109/171/063/9/1091710639.geojson
@@ -56,6 +56,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KN.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880189,
     "wof:geomhash":"fd608b29635cf3392bc6e3725f4bb3d4",
@@ -68,7 +69,7 @@
         }
     ],
     "wof:id":1091710639,
-    "wof:lastmodified":1694492883,
+    "wof:lastmodified":1695886398,
     "wof:name":"Shiekan",
     "wof:parent_id":85676925,
     "wof:placetype":"county",

--- a/data/109/171/068/5/1091710685.geojson
+++ b/data/109/171/068/5/1091710685.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.RS.SE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880191,
     "wof:geomhash":"22ba5a72161ab48eda5346c08ef198ea",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091710685,
-    "wof:lastmodified":1694492793,
+    "wof:lastmodified":1695886472,
     "wof:name":"Sinkat",
     "wof:parent_id":85676867,
     "wof:placetype":"county",

--- a/data/109/171/071/7/1091710717.geojson
+++ b/data/109/171/071/7/1091710717.geojson
@@ -115,6 +115,7 @@
     "wof:concordances":{
         "hasc:id":"SD.RS.PS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880192,
     "wof:geomhash":"584243a4722a37cb7d9506810747e9bb",
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1091710717,
-    "wof:lastmodified":1694492396,
+    "wof:lastmodified":1695886319,
     "wof:name":"Suakin",
     "wof:parent_id":85676867,
     "wof:placetype":"county",

--- a/data/109/171/076/3/1091710763.geojson
+++ b/data/109/171/076/3/1091710763.geojson
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":1091710763,
-    "wof:lastmodified":1694492890,
+    "wof:lastmodified":1695886415,
     "wof:name":"Um Dafug",
     "wof:parent_id":85676871,
     "wof:placetype":"county",

--- a/data/109/171/078/9/1091710789.geojson
+++ b/data/109/171/078/9/1091710789.geojson
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":1091710789,
-    "wof:lastmodified":1694492891,
+    "wof:lastmodified":1695886417,
     "wof:name":"Umm Badda",
     "wof:parent_id":85676889,
     "wof:placetype":"county",

--- a/data/109/171/083/5/1091710835.geojson
+++ b/data/109/171/083/5/1091710835.geojson
@@ -84,6 +84,7 @@
         "hasc:id":"SD.KN.WB",
         "wd:id":"Q10289400"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880197,
     "wof:geomhash":"a05467b4f63cc610b8ff1e532adfac42",
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1091710835,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886473,
     "wof:name":"Wad Banda",
     "wof:parent_id":1108805631,
     "wof:placetype":"county",

--- a/data/109/171/088/3/1091710883.geojson
+++ b/data/109/171/088/3/1091710883.geojson
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":1091710883,
-    "wof:lastmodified":1694492824,
+    "wof:lastmodified":1695886246,
     "wof:name":"Abu Jabra",
     "wof:parent_id":85676875,
     "wof:placetype":"county",

--- a/data/109/171/091/9/1091710919.geojson
+++ b/data/109/171/091/9/1091710919.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"SD.RS.PS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880200,
     "wof:geomhash":"d02f40b976dd78229ee32279467cb29c",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091710919,
-    "wof:lastmodified":1694492850,
+    "wof:lastmodified":1695886306,
     "wof:name":"Jabiet Al Maadin",
     "wof:parent_id":85676867,
     "wof:placetype":"county",

--- a/data/109/171/095/7/1091710957.geojson
+++ b/data/109/171/095/7/1091710957.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"SD.RS.PS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880201,
     "wof:geomhash":"38e023ea2981a56de6730adf178170aa",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091710957,
-    "wof:lastmodified":1694492843,
+    "wof:lastmodified":1695886288,
     "wof:name":"El Qaneb",
     "wof:parent_id":85676867,
     "wof:placetype":"county",

--- a/data/109/171/100/3/1091711003.geojson
+++ b/data/109/171/100/3/1091711003.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.RS.AG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880203,
     "wof:geomhash":"85fdf2bbdf36e6c110256cd6f06bfd71",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091711003,
-    "wof:lastmodified":1694492790,
+    "wof:lastmodified":1695886464,
     "wof:name":"Agig",
     "wof:parent_id":85676867,
     "wof:placetype":"county",

--- a/data/109/171/104/9/1091711049.geojson
+++ b/data/109/171/104/9/1091711049.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SD.SD.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880204,
     "wof:geomhash":"e0213ade3db15aa9faf447c716a3180f",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091711049,
-    "wof:lastmodified":1694492791,
+    "wof:lastmodified":1695886466,
     "wof:name":"Buram",
     "wof:parent_id":85676871,
     "wof:placetype":"county",

--- a/data/109/171/106/7/1091711067.geojson
+++ b/data/109/171/106/7/1091711067.geojson
@@ -71,6 +71,7 @@
     "wof:concordances":{
         "hasc:id":"SS.WR.AB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880206,
     "wof:geomhash":"af69d02729ed1efff9bcfbde928d5db7",
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1091711067,
-    "wof:lastmodified":1694492790,
+    "wof:lastmodified":1695886463,
     "wof:name":"Abyei PCA Area",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/171/111/1/1091711111.geojson
+++ b/data/109/171/111/1/1091711111.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KS.LA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880208,
     "wof:geomhash":"7de4791681654f7618f11021201852af",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091711111,
-    "wof:lastmodified":1694492853,
+    "wof:lastmodified":1695886314,
     "wof:name":"Keilak",
     "wof:parent_id":1108805631,
     "wof:placetype":"county",

--- a/data/109/171/115/7/1091711157.geojson
+++ b/data/109/171/115/7/1091711157.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"SD.KS.AY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SD",
     "wof:created":1473880209,
     "wof:geomhash":"932135896486842801d42f8bd4fd545b",
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091711157,
-    "wof:lastmodified":1694492790,
+    "wof:lastmodified":1695886463,
     "wof:name":"Abyei - Muglad",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/110/880/563/1/1108805631.geojson
+++ b/data/110/880/563/1/1108805631.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":9.45835,
-    "geom:area_square_m":114472789180.640503,
+    "geom:area_square_m":114472789180.641342,
     "geom:bbox":"27.0681959704,9.347221,29.9422873531,14.1214438162",
     "geom:latitude":11.760898,
     "geom:longitude":28.41415,
@@ -106,11 +106,13 @@
     "wof:concordances":{
         "fips:code":"SU62",
         "hasc:id":"SD.WK",
+        "iso:code":"SD-GK",
         "iso:id":"SD-GK"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SD",
     "wof:created":1485561904,
-    "wof:geomhash":"abc6c7f2c7df4b600230197318e97106",
+    "wof:geomhash":"7135f903b3c63ddae321dc8d069fdb80",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -127,7 +129,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1566639478,
+    "wof:lastmodified":1695884326,
     "wof:name":"West Kordofan",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/327/51/85632751.geojson
+++ b/data/856/327/51/85632751.geojson
@@ -1155,6 +1155,7 @@
         "gp:id":23424952,
         "hasc:id":"SD",
         "ioc:id":"SUD",
+        "iso:code":"SD",
         "itu:id":"SDN",
         "loc:id":"n79022301",
         "m49:code":"729",
@@ -1168,6 +1169,7 @@
         "wk:page":"Sudan",
         "wmo:id":"SU"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SD",
     "wof:country_alpha3":"SDN",
     "wof:geom_alt":[
@@ -1192,7 +1194,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1694639595,
+    "wof:lastmodified":1695881256,
     "wof:name":"Sudan",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/768/65/85676865.geojson
+++ b/data/856/768/65/85676865.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.144691,
-    "geom:area_square_m":38128183940.236526,
+    "geom:area_square_m":38128183134.501244,
     "geom:bbox":"33.136397,9.499999,35.082756,12.562287",
     "geom:latitude":11.303332,
     "geom:longitude":34.128361,
@@ -458,16 +458,18 @@
         "gn:id":408654,
         "gp:id":20069913,
         "hasc:id":"SD.BN",
+        "iso:code":"SD-NB",
         "iso:id":"SD-NB",
         "qs_pg:id":331987,
         "unlc:id":"SD-NB",
         "wd:id":"Q309489"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"588c27279f25c39ae5a9dd2bb87635a2",
+    "wof:geomhash":"4400fc27bd2a19c80ab6bdf2cfe34c85",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -484,7 +486,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1690862905,
+    "wof:lastmodified":1695884800,
     "wof:name":"Blue Nile",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/768/67/85676867.geojson
+++ b/data/856/768/67/85676867.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":18.700813,
-    "geom:area_square_m":217417459065.074158,
+    "geom:area_square_m":217417455387.343079,
     "geom:bbox":"33.265656,17.004641,38.581341,23.14827",
     "geom:latitude":19.85454,
     "geom:longitude":35.692622,
@@ -321,15 +321,17 @@
         "gn:id":408646,
         "gp:id":20069904,
         "hasc:id":"SD.RS",
+        "iso:code":"SD-RS",
         "iso:id":"SD-RS",
         "qs_pg:id":895511,
         "wd:id":"Q310120"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"25c1ac8d8ac864e1948835e9a8551fd3",
+    "wof:geomhash":"da7e7f7e2b6f19a6104d62fbc7ead15c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -346,7 +348,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1690862903,
+    "wof:lastmodified":1695884798,
     "wof:name":"Red Sea",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/768/71/85676871.geojson
+++ b/data/856/768/71/85676871.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.866989,
-    "geom:area_square_m":71130446706.872971,
+    "geom:area_square_m":71130444251.034302,
     "geom:bbox":"23.051519,9.655377,25.928409,13.117664",
     "geom:latitude":11.305404,
     "geom:longitude":24.50242,
@@ -250,15 +250,17 @@
         "fips:code":"SU49",
         "gp:id":20069893,
         "hasc:id":"SD.SF",
+        "iso:code":"SD-DS",
         "iso:id":"SD-DS",
         "qs_pg:id":895509,
         "wd:id":"Q838778"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ce63d83c4b9bbde4c75a7f944cbf059e",
+    "wof:geomhash":"92fca2adad499a76e22497498540137d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -275,7 +277,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1690862906,
+    "wof:lastmodified":1695884800,
     "wof:name":"Southern Darfur",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/768/75/85676875.geojson
+++ b/data/856/768/75/85676875.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.436395,
-    "geom:area_square_m":53847935966.946167,
+    "geom:area_square_m":53847935367.632553,
     "geom:bbox":"25.285048,9.488887,27.882781,12.963885",
     "geom:latitude":10.975501,
     "geom:longitude":26.465561,
@@ -90,14 +90,16 @@
         "fips:code":"SU60",
         "gp:id":20069893,
         "hasc:id":"SD.ED",
+        "iso:code":"SD-DE",
         "iso:id":"SD-DE",
         "qs_pg:id":895509
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"542a0c938224b352ea0495aa70023f15",
+    "wof:geomhash":"664499f7d58c8e18418cdf6472e7542c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -114,7 +116,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1636495579,
+    "wof:lastmodified":1695884799,
     "wof:name":"Eastern Darfur",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/768/81/85676881.geojson
+++ b/data/856/768/81/85676881.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.857961,
-    "geom:area_square_m":22335707844.387745,
+    "geom:area_square_m":22335708559.408543,
     "geom:bbox":"21.814939,12.030722,23.24525,14.986525",
     "geom:latitude":13.523658,
     "geom:longitude":22.616428,
@@ -250,15 +250,17 @@
         "fips:code":"SU47",
         "gp:id":20069894,
         "hasc:id":"SD.WF",
+        "iso:code":"SD-DW",
         "iso:id":"SD-DW",
         "qs_pg:id":895510,
         "wd:id":"Q846331"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"59f3abd404c2b0aad9c17382348ee8c4",
+    "wof:geomhash":"84ac38b156d6c51d0a8f53abe18b163b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -275,7 +277,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1690862905,
+    "wof:lastmodified":1695884799,
     "wof:name":"Western Darfur",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/768/85/85676885.geojson
+++ b/data/856/768/85/85676885.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.746367,
-    "geom:area_square_m":33173982565.924046,
+    "geom:area_square_m":33173981750.223953,
     "geom:bbox":"22.555232,10.689637,24.711274,13.557274",
     "geom:latitude":12.326471,
     "geom:longitude":23.359358,
@@ -230,15 +230,17 @@
         "fips:code":"SU61",
         "gp:id":20069894,
         "hasc:id":"SD.CD",
+        "iso:code":"SD-DC",
         "iso:id":"SD-DC",
         "qs_pg:id":895510,
         "wd:id":"Q4116493"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"085572a4fa8b072b5c5bd56005c74588",
+    "wof:geomhash":"f3296f7b00675eb4aedcb1c763fb663f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -255,7 +257,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1690862906,
+    "wof:lastmodified":1695884800,
     "wof:name":"Central Darfur",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/768/89/85676889.geojson
+++ b/data/856/768/89/85676889.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.795089,
-    "geom:area_square_m":21352143723.978378,
+    "geom:area_square_m":21352143735.622627,
     "geom:bbox":"31.698967,15.17866,34.37677,16.629747",
     "geom:latitude":15.8526,
     "geom:longitude":32.84052,
@@ -578,16 +578,18 @@
         "gn:id":379253,
         "gp:id":20069819,
         "hasc:id":"SD.KH",
+        "iso:code":"SD-KH",
         "iso:id":"SD-KH",
         "qs_pg:id":902981,
         "unlc:id":"SD-KH",
         "wd:id":"Q310385"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ec83b8c0f84f4c9af7b6a65daddb41aa",
+    "wof:geomhash":"c33c251a73a1ec24e438631a14cba511",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -604,7 +606,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1690862904,
+    "wof:lastmodified":1695884799,
     "wof:name":"Khartoum",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/768/93/85676893.geojson
+++ b/data/856/768/93/85676893.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.285144,
-    "geom:area_square_m":27343689310.620754,
+    "geom:area_square_m":27343689130.703407,
     "geom:bbox":"32.351211,13.562893,34.294922,15.461092",
     "geom:latitude":14.59524,
     "geom:longitude":33.277354,
@@ -308,15 +308,17 @@
         "gn:id":408648,
         "gp:id":20069916,
         "hasc:id":"SD.GZ",
+        "iso:code":"SD-GZ",
         "iso:id":"SD-GZ",
         "qs_pg:id":908820,
         "wd:id":"Q309469"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8effdd9f4dfb589b1d3f8c7eb41ff15c",
+    "wof:geomhash":"f017ffe2c6b8652e3842e39ce48f912a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -333,7 +335,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1690862904,
+    "wof:lastmodified":1695884799,
     "wof:name":"Gezira",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/768/97/85676897.geojson
+++ b/data/856/768/97/85676897.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.794518,
-    "geom:area_square_m":57490631037.611847,
+    "geom:area_square_m":57490630995.808815,
     "geom:bbox":"33.567792,12.65653,36.552578,15.757235",
     "geom:latitude":14.114088,
     "geom:longitude":35.11419,
@@ -309,15 +309,17 @@
         "gn:id":408649,
         "gp:id":20069906,
         "hasc:id":"SD.GD",
+        "iso:code":"SD-GD",
         "iso:id":"SD-GD",
         "qs_pg:id":895513,
         "wd:id":"Q309478"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3d99b3459256817dff707bc3f2cbf1b2",
+    "wof:geomhash":"c0fa12851c982731d7fb33c18b88addc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -334,7 +336,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1690862905,
+    "wof:lastmodified":1695884800,
     "wof:name":"Gedarif",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/769/01/85676901.geojson
+++ b/data/856/769/01/85676901.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":11.178222,
-    "geom:area_square_m":131128200101.686493,
+    "geom:area_square_m":131128199466.499741,
     "geom:bbox":"31.886663,15.982948,35.694837,22.000004",
     "geom:latitude":18.366409,
     "geom:longitude":33.455958,
@@ -324,15 +324,17 @@
         "gn:id":408664,
         "gp:id":20069903,
         "hasc:id":"SD.RN",
+        "iso:code":"SD-NR",
         "iso:id":"SD-NR",
         "qs_pg:id":1084683,
         "wd:id":"Q849297"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6d60704ec2b6ee7e798eac4d6672d63c",
+    "wof:geomhash":"e76626da56e1ad4b86dda50779255c8f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -349,7 +351,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1690862902,
+    "wof:lastmodified":1695884798,
     "wof:name":"River Nile",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/769/05/85676905.geojson
+++ b/data/856/769/05/85676905.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":31.383281,
-    "geom:area_square_m":365523437710.700073,
+    "geom:area_square_m":365523439544.653137,
     "geom:bbox":"25.0,16.514839,32.654025,22.224918",
     "geom:latitude":19.560661,
     "geom:longitude":29.326212,
@@ -321,16 +321,18 @@
         "gn:id":378389,
         "gp:id":20069999,
         "hasc:id":"SD.NO",
+        "iso:code":"SD-NO",
         "iso:id":"SD-NO",
         "qs_pg:id":1087202,
         "unlc:id":"SD-NO",
         "wd:id":"Q310118"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ae5845846cfbb36ba3689efd5b96e404",
+    "wof:geomhash":"a9991e71bfa624d4db16ce1d04629489",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -347,7 +349,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1690862901,
+    "wof:lastmodified":1695884798,
     "wof:name":"Northern",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/769/09/85676909.geojson
+++ b/data/856/769/09/85676909.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.167694,
-    "geom:area_square_m":38104157495.648987,
+    "geom:area_square_m":38104156097.540825,
     "geom:bbox":"31.529086,11.95105,33.248278,15.227934",
     "geom:latitude":13.364356,
     "geom:longitude":32.317856,
@@ -431,15 +431,17 @@
         "gn:id":408653,
         "gp:id":20069914,
         "hasc:id":"SD.WN",
+        "iso:code":"SD-NW",
         "iso:id":"SD-NW",
         "qs_pg:id":66001,
         "wd:id":"Q311371"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"29f30ae3e8318f5442678668371185ff",
+    "wof:geomhash":"06203f3b31e67c6620f3e4c02f00e2f5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -456,7 +458,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1690862902,
+    "wof:lastmodified":1695884338,
     "wof:name":"White Nile",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/769/15/85676915.geojson
+++ b/data/856/769/15/85676915.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.268581,
-    "geom:area_square_m":39393220974.332611,
+    "geom:area_square_m":39393221761.120163,
     "geom:bbox":"32.911096,11.749768,35.692321,14.109481",
     "geom:latitude":12.910526,
     "geom:longitude":34.04505,
@@ -309,16 +309,18 @@
         "gn:id":408669,
         "gp:id":20069915,
         "hasc:id":"SD.SI",
+        "iso:code":"SD-SI",
         "iso:id":"SD-SI",
         "qs_pg:id":908819,
         "unlc:id":"SD-SI",
         "wd:id":"Q865534"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"223c571c805f5cfbe5584cba5cf7b7b3",
+    "wof:geomhash":"700fc844e96097e5bc9ba048a094c8a6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -335,7 +337,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1690862903,
+    "wof:lastmodified":1695884799,
     "wof:name":"Sennar",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/769/19/85676919.geojson
+++ b/data/856/769/19/85676919.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":26.74298,
-    "geom:area_square_m":317297419741.96875,
+    "geom:area_square_m":317297420738.458191,
     "geom:bbox":"22.769607,11.748951,27.54644,20.026534",
     "geom:latitude":16.218959,
     "geom:longitude":25.551868,
@@ -322,16 +322,18 @@
         "gn:id":408666,
         "gp:id":20069895,
         "hasc:id":"SD.ND",
+        "iso:code":"SD-DN",
         "iso:id":"SD-DN",
         "qs_pg:id":1084682,
         "unlc:id":"SD-DN",
         "wd:id":"Q688306"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"970272fa956380e65d40beea2f4a19ec",
+    "wof:geomhash":"4a1c347e83911a0698cc05a3c463d9e8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -348,7 +350,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1690862901,
+    "wof:lastmodified":1695884798,
     "wof:name":"North Darfur",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/769/23/85676923.geojson
+++ b/data/856/769/23/85676923.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.462871,
-    "geom:area_square_m":78361982040.621872,
+    "geom:area_square_m":78361981563.357651,
     "geom:bbox":"29.214414,9.711841,32.46973,12.746522",
     "geom:latitude":11.291508,
     "geom:longitude":30.835543,
@@ -324,16 +324,18 @@
         "gn:id":408661,
         "gp:id":20069910,
         "hasc:id":"SD.SK",
+        "iso:code":"SD-KS",
         "iso:id":"SD-KS",
         "qs_pg:id":895514,
         "unlc:id":"SD-KS",
         "wd:id":"Q465490"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"034033d3f7ad835d4b950e136ce43be6",
+    "wof:geomhash":"5d708943ac5fe1d54d08a98decd14bd2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -350,7 +352,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1690862902,
+    "wof:lastmodified":1695884798,
     "wof:name":"South Kordufan",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/769/25/85676925.geojson
+++ b/data/856/769/25/85676925.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":15.721298,
-    "geom:area_square_m":187882997141.850494,
+    "geom:area_square_m":187882995303.297546,
     "geom:bbox":"26.958799,12.237103,32.356128,16.536434",
     "geom:latitude":14.837098,
     "geom:longitude":29.751364,
@@ -311,16 +311,18 @@
         "gn:id":408667,
         "gp:id":20069912,
         "hasc:id":"SD.NK",
+        "iso:code":"SD-KN",
         "iso:id":"SD-KN",
         "qs_pg:id":1084684,
         "unlc:id":"SD-KN",
         "wd:id":"Q864093"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a670f57eb07b687f277448fa9e8cabd1",
+    "wof:geomhash":"b7697a95b3fb55e8db52408a69baf4a7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -337,7 +339,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1690862903,
+    "wof:lastmodified":1695884799,
     "wof:name":"North Kordufan",
     "wof:parent_id":85632751,
     "wof:placetype":"region",

--- a/data/856/769/29/85676929.geojson
+++ b/data/856/769/29/85676929.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.325449,
-    "geom:area_square_m":51456364763.443268,
+    "geom:area_square_m":51456366142.329117,
     "geom:bbox":"34.208938,14.20601,37.030525,17.208442",
     "geom:latitude":15.817488,
     "geom:longitude":35.807736,
@@ -304,15 +304,17 @@
         "gn:id":408663,
         "gp:id":20069905,
         "hasc:id":"SD.KA",
+        "iso:code":"SD-KA",
         "iso:id":"SD-KA",
         "qs_pg:id":895512,
         "wd:id":"Q954963"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"127bb47194eee4bd849459f22695041e",
+    "wof:geomhash":"05d7efdc2b0e890cbf34376ab3141c5d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -329,7 +331,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1690862901,
+    "wof:lastmodified":1695884798,
     "wof:name":"Kassala",
     "wof:parent_id":85632751,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.